### PR TITLE
MVC_SPEC-59 Added ValidationError interface and updated BindingResult

### DIFF
--- a/api/src/main/java/javax/mvc/binding/BindingResult.java
+++ b/api/src/main/java/javax/mvc/binding/BindingResult.java
@@ -99,31 +99,31 @@ public interface BindingResult {
     BindingError getBindingError(String param);
 
     /**
-     * Returns an immutable set of all constraint violations detected.
+     * Returns an immutable set of all validation errors detected.
      *
-     * @return All constraint violations detected
+     * @return All validation errors detected
      */
-    Set<ConstraintViolation<?>> getAllViolations();
+    Set<ValidationError> getAllValidationErrors();
 
     /**
-     * Returns an immutable set of all constraint violations detected
+     * Returns an immutable set of all validation errors detected
      * for a parameter binding specified by the given parameter name.
      *
      * @param param The parameter name
-     * @return All constraint violations for this parameter
-     * @see #getViolation(String)
+     * @return All validation errors for this parameter
+     * @see #getValidationError(String)
      */
-    Set<ConstraintViolation<?>> getViolations(String param);
+    Set<ValidationError> getValidationErrors(String param);
 
     /**
-     * Returns a single constraint violation detected for a parameter binding
+     * Returns a single validation error detected for a parameter binding
      * specified by the given parameter name. Will return the first if there
-     * is more than one violation <code>null</code> if no violation was detected.
+     * is more than one and <code>null</code> if no error was detected.
      *
      * @param param The parameter name
-     * @return The first constraint violation for the parameter or <code>null</code>
-     * @see #getViolation(String)
+     * @return The first validation error for the parameter or <code>null</code>
+     * @see #getValidationErrors(String)
      */
-    ConstraintViolation<?> getViolation(String param);
+    ValidationError getValidationError(String param);
 
 }

--- a/api/src/main/java/javax/mvc/binding/ValidationError.java
+++ b/api/src/main/java/javax/mvc/binding/ValidationError.java
@@ -1,0 +1,76 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package javax.mvc.binding;
+
+import javax.validation.ConstraintViolation;
+
+/**
+ * <p>Represents a single validation error detected for a parameter. A validation error always
+ * corresponds to exactly one {@link ConstraintViolation}.</p>
+ *
+ * @author Christian Kaltepoth
+ * @since 1.0
+ */
+public interface ValidationError {
+
+    /**
+     * The parameter name of the value that caused the validation error. This is usually
+     * the name specified with the binding annotation (i.e. {@link javax.ws.rs.FormParam}).
+     *
+     * @return The name of the parameter which caused the error
+     */
+    String getParamName();
+
+    /**
+     * The underlying {@link ConstraintViolation} detected for the parameter.
+     *
+     * @return The violation detected for the parameter
+     */
+    ConstraintViolation<?> getViolation();
+
+    /**
+     * Returns the interpolated error message for this validation error. Same as calling
+     * <code>getViolation().getMessage()</code>.
+     *
+     * @return The human-readable error message
+     */
+    String getMessage();
+
+}


### PR DESCRIPTION
This PR adds the new `ValidationError` interface and modifies `BindingResult` to return sets of `ValidationError` instead of raw `ConstraintViolation`.