### PR TITLE
MVC_SPEC-27 Let ValidationError#getMessage() use the request locale

### DIFF
--- a/api/src/main/java/javax/mvc/binding/ValidationError.java
+++ b/api/src/main/java/javax/mvc/binding/ValidationError.java
@@ -66,8 +66,8 @@ public interface ValidationError {
     ConstraintViolation<?> getViolation();
 
     /**
-     * Returns the interpolated error message for this validation error. Same as calling
-     * <code>getViolation().getMessage()</code>.
+     * Returns the interpolated error message for this validation error using the current
+     * request locale.
      *
      * @return The human-readable error message
      */


### PR DESCRIPTION
Let `ValidationError#getMessage()` return the constraint violation message in the current request locale.

The the corresponding thread on the JSR 371 mailing list for details.