### PR TITLE
MVC_SPEC-67 Make CsrfOptions.EXPLICIT the default

### DIFF
--- a/api/src/main/java/javax/mvc/security/Csrf.java
+++ b/api/src/main/java/javax/mvc/security/Csrf.java
@@ -68,7 +68,7 @@ public interface Csrf {
          */
         OFF,
         /**
-         * Enabling CSRF requires use of {@link javax.mvc.annotation.CsrfValid} explicitly.
+         * Enabling CSRF requires use of {@link javax.mvc.annotation.CsrfValid} explicitly (default).
          */
         EXPLICIT,
         /**

--- a/spec/chapters/security.tex
+++ b/spec/chapters/security.tex
@@ -68,9 +68,9 @@ as HTTP headers.
 The application-level property {\tt javax.mvc.security.CsrfProtection} enables
  CSRF protection when set to one of the possible values defined in
 {\tt javax.mvc.security.Csrf.CsrfOptions}. The default value of this property is
-{\tt CsrfOptions.OFF}. Setting it to any other value will automatically inject a
-CSRF token as an HTTP header; the actual name of this header is 
-implementation dependent.
+{\tt CsrfOptions.EXPLICIT}. Any other value than {\tt CsrfOptions.OFF} will
+automatically inject a CSRF token as an HTTP header; the actual name of this
+header is implementation dependent.
 
 Automatic validation is enabled by setting this
 property to {\tt CsrfOptions.IMPLICIT}, in which case all post requests


### PR DESCRIPTION
This pull request changes the default value of CsrfOption to EXPLICIT.

See the corresponding discussion on the mailing list:

https://java.net/projects/mvc-spec/lists/users/archive/2016-03/message/61