### PR TITLE
MVC_SPEC-69 Simplify default locale resolver algorithm

### DIFF
--- a/api/src/main/java/javax/mvc/locale/LocaleResolver.java
+++ b/api/src/main/java/javax/mvc/locale/LocaleResolver.java
@@ -65,9 +65,7 @@ import java.util.Locale;
  *
  * <p>The MVC implementation is required to provide a default locale resolver with a priority
  * of <code>0</code> which uses the <code>Accept-Language</code> request header to obtain the
- * locale. If resolving the locale this way isn't possible, the implementation should return
- * the application default locale specified via the {@link #DEFAULT_LOCALE} configuration
- * property. If the application default locale hasn't been set, the resolver must return
+ * locale. If resolving the locale this way isn't possible, the default resolver must return
  * {@link Locale#getDefault()}.</p>
  *
  * @author Christian Kaltepoth
@@ -77,15 +75,6 @@ import java.util.Locale;
  * @since 1.0
  */
 public interface LocaleResolver {
-
-    /**
-     * Name of the property that can be set in an application's {@link javax.ws.rs.core.Configuration}
-     * to set a application default locale. This locale will be used if the locale cannot be
-     * determined via the <code>Accept-Language</code> header sent by the client.
-     *
-     * @see javax.ws.rs.core.Application#getProperties()
-     */
-    String DEFAULT_LOCALE = "javax.mvc.locale.LocaleResolver.defaultLocale";
 
     /**
      * <p>Resolve the locale of the current request given a {@link LocaleResolverContext}.</p>

--- a/spec/chapters/i18n.tex
+++ b/spec/chapters/i18n.tex
@@ -103,11 +103,7 @@ which resolves the request locale according to the following algorithm
 \item First check whether the client provided an \code{Accept-Language} request header.
  If this is the case, the locale with the highest quality factor is returned as
  the result. 
-\item Check if there is an {\em application default locale} specified in the JAX-RS 
- configuration. The application default locale can be configured using the key 
- \code{LocaleResolver.DEFAULT\_LOCALE} and a \code{java.util.Locale} as the value. 
- If such a default locale is found, return it as the result.
-\item If the previous steps were not successful, return the system default locale of the 
+\item If the previous step was not successful, return the system default locale of the
  server.
 \end{enumerate}
 


### PR DESCRIPTION
There have been some discussion about the default locale resolver algorithm:

https://java.net/projects/mvc-spec/lists/jsr371-experts/archive/2016-06/message/45

It looks like most (or all?) experts agree that the algorithm should be very simple because providing custom resolvers is VERY easy. 