### PR TITLE
Removed java.net <-> GitHub mirror script

### DIFF
--- a/bin/mirror-git.sh
+++ b/bin/mirror-git.sh
@@ -1,7 +1,0 @@
-cd /tmp
-git clone --bare ssh://spericas@git.java.net/mvc-spec~git
-cd mvc-spec~git.git
-git push --mirror https://github.com/spericas/mvc-spec.git
-cd ..
-rm -rf mvc-spec~git.git
-


### PR DESCRIPTION
This PR removes a shell script which was used to mirror the java.net git repo to GitHub. I guess we don't need this any more. ;-)