### PR TITLE
Automatic deployment of snapshots to Sonatype repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,15 @@ script:
   - make clean all
   - cd ../api
   - mvn clean install -B -V
-after_success:
-  - python <(curl -s https://raw.githubusercontent.com/TouK/sputnik-ci/master/sputnik-ci.py)
+  - cd ..
+deploy:
+  provider: script
+  script: cd api && mvn -s ../.travis/deploy-settings.xml -DperformRelease -DskipTests -Dgpg.skip=true deploy
+  skip_cleanup: true
+  on:
+    repo: mvc-spec/mvc-spec
+    branch: master
+env:
+  global:
+  - secure: Fo25+mOE7lP/cbEdal8xkekfcw5PxidLQY2ETBdXKDFFRGE8Av7C3NgrO4SMcWsLhSMRlHbFUU7QSYzY+O2qPKw9kzvQe7DFY9MytNXU3wDNK+ygEyGUuSrHEOmfIxrElUejTD1OS6yHdAP9vu8GkhyvZA5GkPMpUwfVcpEE/Ao3myfYLY56bbIhY7hycybhj3Ov3/a8OaZmaUAbmgm46HcFkXgmBBDS6qS9xz86JbkbOyXRW+SyGOP3TUqYAN56UxF8+OSJ9iBOvQRloPlxRbgKUXqpJHAr4ZuLpc975FE0B6f5qxRRt5BDympZkSedy+xjbHkc/1dfz2J3M2oiWjckT9AGaB/orzZxlPOFo7HD/6A5XLocJRlNwAuTF3fjtDmyTEftXJocQrV1c6LaB/FS+aU6Jiuf5dr0mUgTpX8UB9yxlaKMj2mf8sX7O+icUjIGBSdDWzTzbnIcACAhsB02wnsWwO6zCYCQD1NbT8p4wW4clYM03ZyDgGNszyqX/k8pf+pmpMLJL+raNoPwFPMscqbqlp8Zn0fW7jXCO0xXpkMJoxw0TCTFMydmCbXhsGDYv9VMU6ioQ/GoLmik8Y9vwSaFK2pxmh4v/OGK5vJJi6sqLUyTEB4BF1Q9tKi1f+yRYGeVfHRBHSevGaB7+JwH9ooOZiitOxzpH67gZ7E=
+  - secure: iY2buZHBhEZct7THPOj+WmuBfOUscefA3BKsxX4S77puZ0vjVdBNUOc83Uim/IJO0+Ni9F9dkfWAMxTaEmgGbXHLb45Rz4rT4vQr9gYRLJOiVtyGYGZpFKh95271woga8JMyda5AmvyqhgyL3MZWsJ6qWseCFeAcD9mwRpNKmPwqK94p8iBNhsKzJC7siifr4nJeU8oxeh9atcPTvI4B+SVsZ9ZIo/PDzTyRqX6F5byPtE99ldLWmieOiM88V9RY5Wb/OlgbssiRjXS8WlL/ATKVJaVin3y95fs6HbxUzV5+VS9poZoG4UmHu+sKpxZRtW3wOn7o1sznNglx/GfE/0GsrKmkRLmn2YwbQ7AeJTi26DiLUbrRGOwzuTuESvM/FjM9/pRu6bOHJaJ79NPKOYTS4EMwRWFoYcdzuYDOii2PVxdFsAa3R68BFpvX5aJm5mmnDOkVZpDUvCq6q+kr/wF5qwdngfgWAE+6Aw7SsVh4MZDqVVvIgVuH6d928BmGy3nZ9bPPidI2Ii8zLf+WTx1K1varQ2KlJpKR1HSbEz8OtSpNac3iojQICZciVL0+pbbcfFsAW7OXvRq9az3loZefvLYIFzDrzeScXWhSm5GPkYfve8b1T/R9nF/gI1dCnyJpcWH8GB2tYyf/xRwLHffQ0LHnsqWKADxwRIakbZ4=

--- a/.travis/deploy-settings.xml
+++ b/.travis/deploy-settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <servers>
+        <server>
+            <id>ossrh</id>
+            <username>${env.SONATYPE_USERNAME}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
+        </server>
+    </servers>
+
+</settings>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,11 +18,6 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>net.java</groupId>
-        <artifactId>jvnet-parent</artifactId>
-        <version>5</version>
-    </parent>
     <groupId>javax.mvc</groupId>
     <artifactId>javax.mvc-api</artifactId>
     <version>1.0-SNAPSHOT</version>
@@ -47,7 +42,16 @@
             <archive>jsr371-users@googlegroups.com</archive>
         </mailingList>
     </mailingLists>
-
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
     <properties>
         <api_package>javax.mvc</api_package>
         <spec_version>1.0</spec_version>
@@ -98,7 +102,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.2</version>
+                <version>2.10.4</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -115,12 +119,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -297,6 +301,32 @@
                                     <classifier>instrumented</classifier>
                                     <classesDirectory>${project.build.directory}/generated-classes/jacoco</classesDirectory>
                                 </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
This PR enables automatic deployment of snapshots to [Sonatype OSSRH](https://oss.sonatype.org).

The combination of Maven deployment, TravisCI with encrypted credentials and Sonatype is a bit difficult to test. But it works fine on my private fork of the repository.