### PR TITLE
Remove overloaded method MvcContext#uri(identifier, params)

### DIFF
--- a/api/src/main/java/javax/mvc/MvcContext.java
+++ b/api/src/main/java/javax/mvc/MvcContext.java
@@ -20,7 +20,6 @@ import javax.mvc.security.Csrf;
 import javax.mvc.security.Encoders;
 import javax.ws.rs.core.Configuration;
 import java.net.URI;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -133,32 +132,6 @@ public interface MvcContext {
      * @return the constructed URI including context- and application path.
      */
     URI uri(String identifier);
-
-    /**
-     * <p>Creates an URI to be matched by a controller method. This is aimed primarily
-     * for use in view rendering technologies to avoid duplicating the values of the
-     * {@link javax.ws.rs.Path} annotations.</p>
-     *
-     * <p>The controller method can either be identified by the simple name of the controller class
-     * and the method name separated by '#' (MyController#myMethod) <em>or</em> by the value
-     * of the {@link UriRef} annotation.</p>
-     *
-     * <p>The created URI includes context- and application path.</p>
-     *
-     * <p>Any {@link javax.ws.rs.PathParam} parameter found in the URI-template
-     * will be replaced by the values of the supplied List in the same order as provided.
-     * Note that query parameters and matrix parameters are not supported
-     * by this method as their order is not predefined.</p>
-     *
-     * <p>For example:</p>
-     * <pre><code>${mvc.uri('MyController#myMethod', ['foo', 42])}</code></pre>
-     *
-     * @param identifier for the controller method.
-     * @param params a list of path parameters.
-     * @return the constructed URI including context- and application path.
-     * @throws IllegalArgumentException if there are any URI template parameters without a supplied value, or if a value is {@code null}.
-     */
-    URI uri(String identifier, List<Object> params);
 
     /**
      * <p>Creates an URI to be matched by a controller method. This is aimed primarily


### PR DESCRIPTION
Method overloading is not supported by EL. See [this discussion](https://groups.google.com/forum/#!topic/jsr371-users/VU2BitCkJsQ).