### PR TITLE
Remove recommendation to use session scope for Csrf

### DIFF
--- a/api/src/main/java/javax/mvc/security/Csrf.java
+++ b/api/src/main/java/javax/mvc/security/Csrf.java
@@ -19,7 +19,6 @@ package javax.mvc.security;
  * Cross Site Request Forgery (CSRF) interface with access to the CSRF header name
  * and the CSRF token value. Implementations of this interface are injectable
  * and accessible from EL via the {@link javax.mvc.MvcContext} class as {@code mvc.csrf}.
- * It is RECOMMENDED for instances of this class to be in session scope.
  *
  * @author Santiago Pericas-Geertsen
  * @see javax.mvc.annotation.CsrfValid


### PR DESCRIPTION
The javadocs of `Csrf` currently recommend to use session scope for it. IMO we should remove this. Implementations could also store the token in a separate cookie which work much better in stateless applications because this doesn't require a session on the server. Therefore I don't think that the spec should recommend anything here.