### PR TITLE
Updated JavaEE 7 to individual JavaEE 8 dependencies

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -234,9 +234,33 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-web-api</artifactId>
-            <version>7.0</version>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>2.0.0.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
JavaEE 8 has been released. Therefore, I updated the dependencies.

I also think that we should depend on individual spec APIs instead of using the full umbrella spec. As we are not officially part of Java EE anymore, we should make our dependencies more explicit.