### PR TITLE
Created new master pom for 'spec' and 'api' modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
 language: java
 jdk: oraclejdk8
 script:
-  - cd spec
   - mvn clean install -B -V
-  - cd ../api
-  - mvn clean install -B -V
-  - cd ..
 deploy:
   provider: script
-  script: cd api && mvn -s ../.travis/deploy-settings.xml -DperformRelease -DskipTests -Dgpg.skip=true deploy
+  script: mvn -s .travis/deploy-settings.xml -DperformRelease -DskipTests -Dgpg.skip=true deploy
   skip_cleanup: true
   on:
     repo: mvc-spec/mvc-spec
@@ -17,4 +13,3 @@ env:
   global:
     - secure: "iJFl971N9L3Bi1+2Z8DGexI+5VObaenykZB9+xohWEKSwzRjusa6/pmzk9+1Cm7RicwDubmx5kmcJvkZki5EF5wVP7lnuHodM2d281052qq/2TcaCN3/DmyGg1QuunCDvZpVWfu1e1F5KMwmp+brt6yaUQVPVN/ehKyT++niO7ZOlhjaB2Gn02bPwW8BZ8aEUt2mNPNwSOJ7R1g4yV+Ji7lleWTIMbJCa1bmg9YncHLyCU8un5vm/fok5fcmwZwrtnckbSU2fgIo8GDXKbblsHOSC2FeYfQFhFzMjh3+bhPhKHmQN7IG4puseNhsuJHGWAzK9hXdaacl+yZ+3WvPr7jf8E4ZL2RinCLaZwxkgHiImrm9Ay9FGMckyyobaPL3Uos1T2MBkhAIle9bh7GAw8GUYbZbCz+IUESTyloQn8Tg4Nspw7xna3W5uBzYySEBgJWKDnQBuWF9HOhJTzJunNWFfLrQEOXaQkyYks5+1VzMm2kKL10hJ55TwG/9zKA7AWspdeaK53ZdtzEfuVLfLymkpKZbtp872sdHbfveV8eeRwFoD4b8TF9K5oxMDQYzeP3N3zlpFsvXtjzQoAOxRE96n/1FiYTQQvbbiTf43lW/HI4QqyA6sV897zjdX5qhnTJT6iFZWxkCgt63Acnrz+CzMdFtL8CCEXnfJi/oIbY="
     - secure: "SPvU5ZPDcFpIGScO42HXWrGoUw/s8IIDJrj9Ne343ag7dNXq91Kd2sxYE3EyYiZVt/6YIneYv4adezzfD94xHL2apiaIRy+OzheG8ohgU5nSxra4jXi+gUQMjrmIybL6qyQe7rDxI6zkUvjB6h10i3bZw4a6lf1afqFwmrHST6dXBqIKgmOJ668nzmOqxozjQ1PfbgS1N5D5s5Oh0zncIq7dqP26fK3lrytHfq+cfjMolNeE99CXDwy2HJkFoYtmjCCrT6mi5WzVUGa2g3w1nidDGqIIOIWImu4GLdgaKCZb55XFbtgTNzzYf8SXvmgqTxqftCL8pyLk1vMX3dxctn/E9AdwkhpcXouCJkDvSJ2LznYAjX0CwDIAK34/T7Ad60sjBpZGK17QcNRkvqyG6A8434GKbaY8sRXSQJIyTHgPNqDYTuYKJDehiKY2xF5zeG3aVjHO5jzoeNNMlgeOT3tjGZAK6z5szDQXSInMozMHqdu93pHSBzKn17e3pVGuelOo42B1bxsPSHQVbSWXIl0n2fhNe1B2k5PI++D4qwEBJ0Cpe9nwGmUJ0SB1u5omSDOiW2+cueE7dsUV6KWLvXolD8h37fVOkbgpULbIsJXLcwYnjP3Zvj4pf9KEPPSi5vgBYCOh0R1bLDh2emzcMPWlHlvZaeRCucTT7eJ4etI="
-

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>javax.mvc</groupId>
+    <artifactId>javax.mvc-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>MVC ${project.version} Parent</name>
+    <url>https://www.mvc-spec.org/</url>
+
+    <organization>
+        <name>Ivar Grimstad</name>
+        <url>https://www.mvc-spec.org/</url>
+    </organization>
+
+    <issueManagement>
+        <system>github</system>
+        <url>https://github.com/mvc-spec/mvc-spec/issues</url>
+    </issueManagement>
+
+    <mailingLists>
+        <mailingList>
+            <name>JSR371 Expert Group List</name>
+            <archive>jsr371-experts@googlegroups.com</archive>
+        </mailingList>
+        <mailingList>
+            <name>MVC Specification Users List</name>
+            <archive>jsr371-users@googlegroups.com</archive>
+        </mailingList>
+    </mailingLists>
+
+    <scm>
+        <connection>scm:git:https://github.com/mvc-spec/mvc-spec.git</connection>
+        <developerConnection>scm:git:https://github.com/mvc-spec/mvc-spec.git</developerConnection>
+    </scm>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <modules>
+      <module>spec</module>
+      <module>api</module>
+    </modules>
+
+</project>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -45,7 +45,11 @@
             <archive>jsr371-users@googlegroups.com</archive>
         </mailingList>
     </mailingLists>
-    
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
This PR adds a new `pom.xml` file in the root directory with `spec` and `api` being modules. This simplifies the build process a lot as you only need to run 'mvn' in the root directory and not in each subdirectory.

A few notes:
  * Only the `api` module is actually deployed to the Maven repo. The `spec` and `parent` are not.
  * Actually the root pom isn't a real parent of the modules because both modules aren't depending on it. IMHO that is required, because otherwise we would need to deploy the parent to the Maven repo too.

I'm still not 100% happy with this setup, but IMHO it is an improvement over the current situation.