### PR TITLE
Added Florian Hirsch to the expert group listing

### DIFF
--- a/spec/src/main/asciidoc/chapters/intro.asciidoc
+++ b/spec/src/main/asciidoc/chapters/intro.asciidoc
@@ -123,6 +123,7 @@ This specification is being developed as part of https://jcp.org/en/jsr/detail?i
 |Paul Nicolucci (IBM)
 |Kito D. Mann (Individual Member)
 |Rahman Usta (Individual Member)
+|Florian Hirsch (adorsys GmbH & Co KG)
 |===
 
 [[contributors]]
@@ -134,9 +135,7 @@ The following are the contributors of the specification:
 [cols="1,1"]
 |===
 |Daniel Dias dos Santos
-|Florian Hirsch
 |Phillip Krüger
-|
 |===
 
 [[acks]]


### PR DESCRIPTION
The PR adds Florian Hirsch (@lefloh) to the expert group member listing