### PR TITLE
Use nonFinal=true for spec-version-maven-plugin

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -68,9 +68,11 @@
                 <version>1.2</version>
                 <configuration>
                     <spec>
-                        <nonFinal>false</nonFinal>
+                        <nonFinal>true</nonFinal>
                         <jarType>api</jarType>
-                        <specVersion>${spec_version}</specVersion>
+                        <specVersion>0.0</specVersion>
+                        <newSpecVersion>${spec_version}</newSpecVersion>
+                        <specBuild>01</specBuild>
                         <specImplVersion>${spec_impl_version}</specImplVersion>
                         <apiPackage>${api_package}</apiPackage>
                     </spec>


### PR DESCRIPTION
I ran into some issues while preparing the public review release. The `spec-version-maven-plugin` was complaining about the `Bundle-Version` created during the build.

I had a closed look at the configuration of the plugin and discovered that it doesn't seem to be configured correctly. Currently, the plugin generates an output like this:

```
[INFO] -- spec properties --
[INFO] spec.implementation.version = 1.0
[INFO] spec.specification.version = 1.0
[INFO] spec.bundle.symbolic-name = javax.mvc-api
[INFO] spec.bundle.spec.version = 1.0
[INFO] spec.extension.name = javax.mvc
[INFO] spec.bundle.version = 1.0
```

This looks like a final version of the spec, but that's not correct. In the `pom.xml` I found `<nonFinal>false</nonFinal>`, which is IMO not correct. I adjusted the configuration of the plugin and now the output is like this.

For a regular snapshot version like `1.0-SNAPSHOT` the output is like this:

```
[INFO] -- spec properties --
[INFO] spec.implementation.version = 1.0
[INFO] spec.specification.version = 0.0.99.01
[INFO] spec.bundle.symbolic-name = javax.mvc-api
[INFO] spec.bundle.spec.version = 0.0.99.b01
[INFO] spec.extension.name = javax.mvc
[INFO] spec.bundle.version = 0.0.99.b01
```

For the upcoming public review version the output is like this:

```
[INFO] -- spec properties --
[INFO] spec.implementation.version = 1.0-pr
[INFO] spec.specification.version = 0.0.99.01
[INFO] spec.bundle.symbolic-name = javax.mvc-api
[INFO] spec.bundle.spec.version = 0.0.99.b01
[INFO] spec.extension.name = javax.mvc
[INFO] spec.bundle.version = 0.0.99.b01
```

The configuration is now much closer to what the Security JSR [is doing](https://github.com/javaee/security-api/blob/master/pom.xml).

Actually it looks like releasing versions like `1.0-edr`, `1.0-edr2` and `1.0-pr` seems to be uncommon. Other specs often release version like `1.0.b12`. Actually I prefer this pattern, as it allows more frequent releases. But we shouldn't change this now I guess.