### PR TITLE
URL in View example

### DIFF
--- a/api/src/main/java/javax/mvc/MvcContext.java
+++ b/api/src/main/java/javax/mvc/MvcContext.java
@@ -125,7 +125,7 @@ public interface MvcContext {
      *
      * <p>This method assumes that there is no parameter in the URI-template.</p>
      *
-     * <p>For example:</p>
+     * <p>For example in JSP:</p>
      * <pre><code>${mvc.uri('MyController#myMethod')}</code></pre>
      *
      * @param identifier for the controller method.
@@ -150,8 +150,8 @@ public interface MvcContext {
      * Please note that the map must contain values for all path parameters
      * as they are required for building the URI. All other parameters are optional.</p>
      * 
-     * <p>For example:</p>
-     * <pre><code>${mvc.uri('MyController#myMethod' {'foo': 'bar', 'id': 42})}</code></pre>
+     * <p>For example in JSP:</p>
+     * <pre><code>${mvc.uri('MyController#myMethod', {'foo': 'bar', 'id': 42})}</code></pre>
      *
      * @param identifier for the controller method.
      * @param params a map of path-, query- and matrix parameters.

--- a/spec/src/main/asciidoc/chapters/controllers.asciidoc
+++ b/spec/src/main/asciidoc/chapters/controllers.asciidoc
@@ -310,11 +310,11 @@ Building URIs in a View
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 In views links and form actions require a URI. To avoid repeating the declarative mapping to URIs on controller 
-methods MVC provides a way to build URIs from the `MvcContext`:
+methods MVC provides a way to build URIs from the `MvcContext`, as an example in JSP:
 
 [source,html]
 ----
-${mvc.uri(’MyController#myMethod’ {’id’: 42, ’foo’: ’bar’})}
+${mvc.uri('MyController#myMethod', {'id': 42, 'foo': 'bar'})}
 ----
 
 The controller method can either be identified by the simple name of the controller class and the method name separated by 


### PR DESCRIPTION
Fixed the Url builder example in the spec and in the JavaDoc (added the comma)

see https://groups.google.com/forum/#!topic/jsr371-users/vSd9WnTsEag