### PR TITLE
Added new CsrfValidationException class (#82)

### DIFF
--- a/api/src/main/java/javax/mvc/security/CsrfValidationException.java
+++ b/api/src/main/java/javax/mvc/security/CsrfValidationException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package javax.mvc.security;
+
+/**
+ * This exception is thrown by the MVC implementation if the CSRF token validation fails.
+ * By default this will result in a 403 status code sent to the client. The application
+ * can provide a custom exception mapper for this exception type to customize this
+ * default behavior.
+ *
+ * @author Christian Kaltepoth
+ * @since 1.0
+ */
+public class CsrfValidationException extends RuntimeException {
+
+    private static final long serialVersionUID = -1083828917314728056L;
+
+    /**
+     * Create a new CsrfValidationException
+     *
+     * @param message the detail message
+     */
+    public CsrfValidationException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
Hey everyone! I started to implement #82. Back then we decided to throw a `CsrfValidationException` if the CSRF token validation fails. By default, the MVC implementation will handle this exception with an exception mapper which simply sends a 403 status code. But users can also create a custom exception mapper to customize this default behavior.

A few open questions:

* What do you think of providing a `message` to the constructor? This content of the message isn't defined anywhere and just contains some details like "token not found", "token invalid" in the RI. An alternative would be to either remove the string or replace it with an enum describing what went wrong. But I don't think that this will be very useful.
* The exception extends `RuntimeException`, which is a good choice I guess.

What do you think?