### PR TITLE
Allow both 303 and 302 status codes for redirects (#100)

### DIFF
--- a/spec/src/main/asciidoc/chapters/controllers.asciidoc
+++ b/spec/src/main/asciidoc/chapters/controllers.asciidoc
@@ -141,10 +141,10 @@ public String redirect() {
 }
 ----
 
-In either case, the HTTP status code returned is 303 (See Other) and relative paths are resolved relative to the application path 
-–for more information please refer to the Javadoc for the `seeOther` method in JAX-RS. 
+In either case, relative paths are resolved relative to the application path - for more information please refer to the Javadoc for the `seeOther` method in JAX-RS.
 It is worth noting that redirects require client cooperation (all browsers support it, but certain CLI clients may not) 
 and result in a completely new request-response cycle in order to access the intended controller.
+If a controller returns a `redirect:` view path, MVC implementations SHOULD use the 303 (See other) status code for the redirect, but MAY prefer 302 (Found) if HTTP 1.0 compatibility is required.
 
 MVC applications can leverage CDI by defining beans in scopes such as request and session. 
 A bean in request scope is available only during the processing of a single request, while a bean in session scope is


### PR DESCRIPTION
Sorry for starting another discussion about this, but I would like to propose another change related to #100.

The current wording in the spec **forces** implementations to use 303 (See other) for redirects resulting from using the `redirect:` prefix. But 303 has a few disadvantages:

* It requires HTTP 1.1 and won't work for HTTP 1.0 clients.
* Most other frameworks prefer 302 (Found) which works the same way in almost any browsers but is HTTP 1.0 compatible.
* Even the Servlet API users 302 for `HttpServletResponse.sendRedirect()`.

The problem I'm seeing is that **if** another MVC implementations decides to prefer 302 for one of the above reasons, it would break spec compliance. As I see good arguments for preferring 302 in some situations, we shouldn't force implementations to choose one status code over the other. At least I don't see any benefit from that. Especially because it is an implementation details most users won't care about.

Therefore, I adjusted the text so that the spec recommends to use 303 but also allows 302.

What do you think?