### PR TITLE
Remove Servlet API dependency (#73)

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -263,12 +263,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <version>2.0</version>

--- a/api/src/main/java/javax/mvc/MvcContext.java
+++ b/api/src/main/java/javax/mvc/MvcContext.java
@@ -57,7 +57,6 @@ public interface MvcContext {
      * <p>For example, given the URI {@code http://host:port/myapp/resources/hello},
      * this method returns {@code /myapp}.</p>
      *
-     * @see javax.servlet.ServletContext#getContextPath()
      * @return the application's context path.
      */
     String getContextPath();

--- a/api/src/main/java/javax/mvc/engine/ViewEngineContext.java
+++ b/api/src/main/java/javax/mvc/engine/ViewEngineContext.java
@@ -16,21 +16,21 @@
 package javax.mvc.engine;
 
 import javax.mvc.Models;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
+import java.io.OutputStream;
 
 /**
  * <p>Contextual data used by a {@link javax.mvc.engine.ViewEngine} to process a view.
  * This includes the view name, the models instance and the request and response
- * objects from the Servlet container, among other data.</p>
+ * objects from the container, among other data.</p>
  *
  * @author Santiago Pericas-Geertsen
+ * @author Christian Kaltepoth
  * @see javax.mvc.engine.ViewEngine
- * @see javax.servlet.http.HttpServletRequest
- * @see javax.servlet.http.HttpServletResponse
  * @since 1.0
  */
 public interface ViewEngineContext {
@@ -50,19 +50,56 @@ public interface ViewEngineContext {
     Models getModels();
 
     /**
-     * Returns HTTP request object from the Servlet container.
+     * Returns the HTTP request object from the container. The type of the request object
+     * depends on the environment. In a servlet environment you can use this method to get
+     * the <code>HttpServletRequest</code> object.
      *
+     * @param type The expected type of the HTTP request object.
+     * @param <T>  The expected type of the HTTP request object
      * @return HTTP request object.
      */
-    HttpServletRequest getRequest();
+    <T> T getRequest(Class<T> type);
 
     /**
-     * Returns HTTP response object from the servlet container. The underlying
-     * output stream should be used to write the result of processing a view.
+     * <p>Returns the HTTP response object from the container. The type of the response object
+     * depends on the environment. In a servlet environment you can use this method to get
+     * the <code>HttpServletResponse</code> object.</p>
      *
+     * <p>Please note that you should generally prefer using {@link #getOutputStream()}
+     * and {@link #getResponseHeaders()} to write the result of processing the view, because
+     * these methods are guaranteed to work in all supported environments.</p>
+     *
+     * @param type The expected type of the HTTP response object.
+     * @param <T>  The expected type of the HTTP request object
      * @return HTTP response object.
      */
-    HttpServletResponse getResponse();
+    <T> T getResponse(Class<T> type);
+
+    /**
+     * Get the mutable response headers multivalued map. This map can be modified
+     * to change the HTTP response headers. Please note that changing the map will only have
+     * an effect on the headers if modifications are performed before data is written
+     * to the output stream obtained from {@link #getOutputStream()}.
+     *
+     * @return mutable multivalued map of response headers.
+     */
+    MultivaluedMap<String, Object> getResponseHeaders();
+
+    /**
+     * The output stream which should be used to write the result of processing a view.
+     *
+     * @return The output stream
+     */
+    OutputStream getOutputStream();
+
+    /**
+     * The media type to use for the response. Please note that {@link ViewEngine}
+     * implementations should respect the <i>charset</i> parameter of the media type when
+     * writing data to the output stream obtained from {@link #getOutputStream()}.
+     *
+     * @return The media type
+     */
+    MediaType getMediaType();
 
     /**
      * Returns the {@link javax.ws.rs.core.UriInfo} instance containing information


### PR DESCRIPTION
This pull request addresses #73, which was discussed quite some time ago. JAX-RS does NOT depend on the Servlet API and can therefore be used in other environments. As MVC is built on top of JAX-RS, it makes no sense to introduce a dependency on the Servlet API.

The only class which currently depends on the Servlet API is `ViewEngineContext`, which exposes the `HttpServletRequest` and the `HttpServletResponse`. Beside the fact that this is the only reason for us to depend on Servlet, exposing these Servlet specific classes is bad for other reasons:

* It allows to write the result of processing the view directly to `HttpServletResponse.getOutputStream()` which basically completely bypasses JAX-RS.
* It allows to write to `HttpServletResponse.getWriter()` which may use a completely different encoding from the one negotiated via `@Produces`.

This pull request contains the following changes:
* The Servlet API is removed from our `pom.xml`.
* Removed a reference to the Servlet API for the `MvcContext` javadocs.
* Remove `ViewEngineContext.getRequest()` and `ViewEngineContext.getResponse()`.
* Added `ViewEngineContext.getOutputStream()` which will be the primary way to obtain the stream to write the view to.
* Added `ViewEngineContext.getResponseHeaders()` which exposes a mutable map which can be used to modify the HTTP response headers. I don't really the mutable map approach, but that's the way JAX-RS exposes such headers for `MessageBodyWriter`, so we should be consistent with JAX-RS here.
* Added `ViewEngineContext.getMediaType()` to provide the `ViewEngine` with all required information about the negotiated media type and character encoding.
* I understand that there **may** be reasons for `ViewEngine` implementation to need the `HttpServletRequest` or `HttpServletResponse`. For these cases I added `ViewEngineContext.getRequest(Class<T>)`  and `ViewEngineContext.getResponse(Class<T>)`. These methods don't have a hard dependency on the Servlet API but allow to obtain the request via `getRequest(HttpServletRequest.class)`. It is a bit similar to JSF's `ExternalContext.getRequest()` but more type safe like `EntityManager.unwrap(Class)`. The nice thing about these methods is that they also support other request/response objects in non-servlet environments.

I already modified Ozark to support this new API on a private branch. It worked great! And I was even able to fix some really serve encoding issues in some of the 3rd party view engines.

This is a very huge change. But it is worth the effort. So any feedback is welcome. 