### PR TITLE
Removed @ValidateOnExecution references from the specification

### DIFF
--- a/spec/src/main/asciidoc/chapters/validation.asciidoc
+++ b/spec/src/main/asciidoc/chapters/validation.asciidoc
@@ -117,7 +117,6 @@ public class FormController {
     private ErrorDataBean error;
     
     @POST
-    @ValidateOnExecution(type = ExecutableType.NONE)
     public Response formPost(@Valid @BeanParam FormDataBean form) {
         if (br.isFailed()) {
             // fill out ErrorDataBean ...
@@ -141,7 +140,6 @@ include::{mvc-api-source-dir}javax/mvc/binding/ValidationError.java[lines=20..-1
 
 The presence of the injection target for the field `br` indicates to an implementation that controller methods in this class can handle errors.
 As a result, methods in this class that validate parameters should call `br.isFailed()` to verify if validation errors were found. 
-footnote:[The `ValidateOnExecution` annotation is necessary to ensure that CDI and BV do not abort the invocation upon detecting a violation. Thus, to ensure the correct semantics, validation must be performed by the JAX-RS implementation before the method is called.]
 
 The class `BindingResult` provides methods to get detailed information about any violations found during validation. 
 Instances of this class are always in request scope; the reader is referred to the Javadoc for more information.


### PR DESCRIPTION
I just merged mvc-spec/ozark#156 which contains some major improvements for the validation handling with Ozark. Especially you won't need to explicitly disable the native JAX-RS/CDI validation using `@ValidateOnExecution(NONE)` on Glassfish any more. Please see the comments on mvc-spec/ozark#156 for details.

Therefore, I would like to remove references to `@ValidateOnExecution(NONE)` from the specification document. There is no reason for mentioning this workaround if the RI doesn't need it anymore, although similar support for other application servers are still WIP.

This will basically fix #66.