### PR TITLE
Minor adjustments for title page

### DIFF
--- a/spec/src/main/asciidoc/spec.asciidoc
+++ b/spec/src/main/asciidoc/spec.asciidoc
@@ -1,4 +1,4 @@
-= MVC: Model-View-Controller API
+= MVC 1.0: Model-View-Controller Specification
 Ivar Grimstad, Christian Kaltepoth
 Version 1.0 Public Review, December 2017
 
@@ -21,10 +21,6 @@ endif::[]
 
 
 :mvc-api-source-dir: ../../../../../api/src/main/java/
-
-[NOTE]
-[.text-center]
-Comments to jsr371-users@googlegroups.com
 
 include::chapters/license.asciidoc[]
 


### PR DESCRIPTION
I just started to proofread the spec again and I will create some pull requests in the next days with a ton of minor improvements and corrections. So stay tuned. :smile: 

This PR contains the following changes:
* The title page now reads "MVC 1.0 [newline] Model-View-Controller Specification". I think the spec version is so important that it should be mentioned in the title. And actually it is not an API but a specification. I think this is a better fit.
* I removed the nearly blank page which just contains the mailing list. The mailing list is also mentioned in the intro chapter, so there is no need to also have it on a separate page directly after the TOC.

Please review ASAP. I'll merge this one in a few days.
 