### PR TITLE
Reworded specification goals

### DIFF
--- a/spec/src/main/asciidoc/chapters/intro.asciidoc
+++ b/spec/src/main/asciidoc/chapters/intro.asciidoc
@@ -21,11 +21,10 @@ Goals
 The following are goals of the API:
 
 [horizontal]
-Goal 1:: Leverage existing Java EE technologies.
-Goal 2:: Integrate with CDI [<<cdi11,2>>] and Bean Validation [<<bv11,3>>].
-Goal 3:: Define a solid core to build MVC applications without necessarily supporting all the features in its first version.
-Goal 4:: Explore layering on top of JAX-RS for the purpose of re-using its matching and binding layers.
-Goal 5:: Provide built-in support for JSPs and Facelets view languages.
+Goal 1:: Leverage existing Java EE technologies like CDI [<<cdi11,2>>] and Bean Validation [<<bv11,3>>].
+Goal 2:: Define a solid core to build MVC applications without necessarily supporting all the features in its first version.
+Goal 3:: Build on top of JAX-RS for the purpose of re-using its matching and binding layers.
+Goal 4:: Provide built-in support for JSPs and Facelets view languages.
 
 [[non_goals]]
 Non-Goals


### PR DESCRIPTION
This PR contains some changes to the specification goals:

* I merged Goal 1 ("Use existing EE technologies") and Goal 2 ("Use CDI and Bean Validation").
* I changed "Explore layering on top of JAX-RS" to "Build on top of JAX-RS". IMO it makes no sense any more to state that we **think about** building on top of JAX-RS. Building on top of JAX-RS is a fundamental concept of the spec.

Please provide feedback ASAP. I'll merge this one in the next days.