### PR TITLE
TCK annotations for Chapter 2

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,11 +42,11 @@ element. Can be used to exlude explanatory phrases contained in an element marke
 * `tck-needs-update`: The tagged element must be marked with a note in the TCK audit file saying
 that the tests for this assertion need to be updated, e.g. due to a spec update. Can be used
 together with `tck-testable` and `tck-not-testable`: `[tck-testable tck-needs-update]#Some sentence...#`.
-* `tck-test-id-SOME_ID`: This tag defines an ID that has to be used to reference this particular assertion
+* `tck-id-SOME_ID`: This tag defines an ID that has to be used to reference this particular assertion
 in the TCK. SOME_ID can be any text, number or special character`- anything up to the next space " " or
 closing bracket ]` will be taken as the ID. Can be used together with `tck-testable`:
-`[tck-testable tck-test-id-http://some.issue.tracker/url]#Some sentence...#`. `tck-testable` without a
-defined test-id will get a letter assigned as their ID, in the order of apperance within their section
+`[tck-testable tck-id-http://some.issue.tracker/url]#Some sentence...#`. `tck-testable` without a
+defined id will get a letter assigned as their ID, in the order of apperance within their section
 (a, b, c, ...)
 
 

--- a/spec/src/main/asciidoc/chapters/assertions.asciidoc
+++ b/spec/src/main/asciidoc/chapters/assertions.asciidoc
@@ -6,20 +6,6 @@ Summary of Assertions
 [[list-of-assertions]]
 List of all Assertions
 ~~~~~~~~~~~~~~~~~~~~~~
-[[mvc:controller]]
-*\[[mvc:controller]]* [tck-testable tck-test-id-Controller_Annotation]#Controller methods are JAX-RS resource methods annotated with `@Controller`.#
-
-[[mvc:all-controllers]]
-*\[[mvc:all-controllers]]* All resource methods in a class annotated with `@Controller` must be controllers.
-
-[[mvc:void-controllers]]
-*\[[mvc:void-controllers]]* Controller methods that return void must be annotated with `@View`.
-
-[[mvc:cdi-beans]]
-*\[[mvc:cdi-beans]]* MVC beans are managed by CDI.
-
-[[mvc:per-request]]
-*\[[mvc:per-request]]* Default scope for MVC beans is request scope.
 
 [[mvc:validation-result]]
 *\[[mvc:validation-result]]* If validation fails, controller methods must still be called if a `ValidationResult` field or property is defined.
@@ -47,9 +33,6 @@ List of all Assertions
 
 [[mvc:null-controllers]]
 *\[[mvc:null-controllers]]* The `@View` annotation is treated as a default value for any controller method that returns a null value.
-
-[[mvc:redirect]]
-*\[[mvc:redirect]]* Support HTTP redirects using the redirect: prefix and a controller return type of String.
 
 [[mvc:annotation-inheritance]]
 *\[[mvc:annotation-inheritance]]* Annotation inheritance is derived from JAX-RS and extended to MVC annotations.

--- a/spec/src/main/asciidoc/chapters/controllers.asciidoc
+++ b/spec/src/main/asciidoc/chapters/controllers.asciidoc
@@ -9,10 +9,9 @@ This chapter introduces the three components that comprise the
 Controllers
 ~~~~~~~~~~~
 
-An _MVC controller_ is a JAX-RS [<<jaxrs20,5>>] resource method decorated by `@Controller`. [<<mvc:controller>>] 
-If this annotation is applied to a class, then all resource methods in it are regarded as controllers [<<mvc:all-controllers>>]. 
-Using the `@Controller` annotation on a subset of methods defines a hybrid class in which certain methods are controllers and
-others are traditional JAX-RS resource methods.
+[tck-testable tck-id-ctrl-method]#An _MVC controller_ is a JAX-RS [<<jaxrs20,5>>] resource method decorated by `@Controller`#.
+[tck-testable tck-id-ctrl-class]#If this annotation is applied to a class, then all resource methods in it are regarded as controllers#.
+[tck-testable tck-id-ctrl-hybrid]#Using the `@Controller` annotation on a subset of methods defines a hybrid class in which certain methods are controllers and others are traditional JAX-RS resource methods.#
 
 A simple hello-world controller can be defined as follows:
 
@@ -29,15 +28,15 @@ public class HelloController {
 }
 ----
 In this example, `hello` is a controller method that returns a path to a JavaServer Page (JSP). 
-The semantics of controller methods differ slightly from JAX-RS resource methods; in particular, a return type of `String` is
-interpreted as a view path rather than text content. Moreover, the default media type for a response is assumed to be `text/html`, but otherwise can
-be declared using `@Produces` just like in JAX-RS.
+The semantics of controller methods differ slightly from JAX-RS resource methods;
+[tck-testable tck-id-return-string]#in particular, a return type of `String` is interpreted as a view path rather than text content#.
+[tck-testable tck-id-default-mediatype]#Moreover, the default media type for a response is assumed to be `text/html`, but otherwise can be declared using `@Produces` just like in JAX-RS#.
 
 A controller’s method return type determines how its result is processed:
 
-void:: A controller method that returns void is REQUIRED to be decorated by `@View` [<<mvc:void-controllers>>].
-String:: A string returned is interpreted as a view path.
-Response:: A JAX-RS `Response` whose entity’s type is one of the above.
+void:: [tck-testable tck-id-return-void]#A controller method that returns void is REQUIRED to be decorated by `@View`#.
+String:: [tck-testable tck-id-return-string2]#A string returned is interpreted as a view path#.
+Response:: [tck-testable tck-id-return-response]#A JAX-RS `Response` whose entity’s type is one of the above#.
 
 The following class defines equivalent controller methods:
 
@@ -67,12 +66,14 @@ public class HelloController {
 }
 ----
 
-Controller methods that return a non-void type may also be decorated with `@View` as a way to specify a _default_ view for the controller. 
-The default view MUST be used only when such a non-void controller method returns a `null` value [<<mvc:null-controllers>>].
+Controller methods that return a non-void type may also be decorated with `@View` as a way to specify a _default_ view for the controller.
+[tck-testable tck-id-non-null-viewable]#The default view MUST be used only when such a non-void controller method returns a `null` value#.
 
-Note that, even though controller methods return types are restricted as explained above, MVC does not impose any restrictions on parameter types
-available to controller methods: i.e., all parameter types injectable in JAX-RS resources are also available in  controllers. 
-Likewise, injection of fields and properties is unrestricted and fully compatible with JAX-RS. Note the restrictions explained in Section <<controller_instances>>.
+Note that, even though controller methods return types are restricted as explained above, MVC does not impose any restrictions on parameter types available to controller methods:
+i.e.,
+[tck-testable tck-id-inject-param-types]#all parameter types injectable in JAX-RS resources are also available in controllers#.
+[tck-testable tck-id-inject-field-props]#Likewise, injection of fields and properties is unrestricted and fully compatible with JAX-RS#.
+Note the restrictions explained in Section <<controller_instances>>.
 
 Controller methods handle a HTTP request directly. Sub-resource locators as described in the JAX-RS Specification [<<jaxrs20,5>>] are not supported by MVC.
 
@@ -80,20 +81,20 @@ Controller methods handle a HTTP request directly. Sub-resource locators as desc
 Controller Instances
 ^^^^^^^^^^^^^^^^^^^^
 
-Unlike in JAX-RS where resource classes can be native (created and managed by JAX-RS), CDI beans, managed beans or EJBs, MVC classes are REQUIRED to be CDI-managed beans only [<<mvc:cdi-beans>>]. 
-It follows that a hybrid class that contains a mix of JAX-RS resource methods and MVC controllers must also be CDI managed.
+Unlike in JAX-RS where resource classes can be native (created and managed by JAX-RS), CDI beans, managed beans or EJBs,
+[tck-testable tck-id-ctrl-cdi]#MVC classes are REQUIRED to be CDI-managed beans only#.
+[tck-testable tck-id-ctrl-cdi-hybrid]#It follows that a hybrid class that contains a mix of JAX-RS resource methods and MVC controllers must also be CDI managed#.
 
-Like in JAX-RS, the default resource class instance lifecycle is _per-request_ [<<mvc:per-request>>]. 
-Implementations MAY support other
-lifecycles via CDI; the same caveats that apply to JAX-RS classes in other lifecycles applied to MVC classes.
-In particular, CDI may need to create proxies when, for example, a per-request instance is as a member of a per-application instance.
+[tck-testable tck-id-request-scope-default]#Like in JAX-RS, the default resource class instance lifecycle is _per-request_#.
+Implementations MAY support other lifecycles via CDI; the same caveats that apply to JAX-RS classes in other lifecycles applied to MVC classes.
+[tck-testable tck-id-scope-proxy]#In particular, CDI may need to create proxies when, for example, a per-request instance is as a member of a per-application instance#.
 See [<<jaxrs20,5>>] for more information on lifecycles and their caveats.
 
 [[response]]
 Response
 ^^^^^^^^
 
-Returning a `Response` object gives applications full access to all the parts in a response, including the headers. 
+[tck-testable tck-id-response-header]#Returning a `Response` object gives applications full access to all the parts in a response, including the headers#.
 For example, an instance of `Response` can modify the HTTP status code upon encountering an error condition; 
 JAX-RS provides a fluent API to build responses as shown next.
 
@@ -118,7 +119,7 @@ For more information, the reader is referred to the Javadoc for the `Response` 
 Redirect and @RedirectScoped
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-As stated in the previous section, controllers can redirect clients by returning a `Response` instance using the JAX-RS API. 
+As stated in the previous section, [tck-testable tck-id-redirect-response]#controllers can redirect clients by returning a `Response` instance using the JAX-RS API#.
 For example,
 
 [source,java,numbered]
@@ -130,8 +131,8 @@ public Response redirect() {
 }
 ----
 
-Given the popularity of the POST-redirect-GET pattern, MVC implementations are REQUIRED to support view paths prefixed by 
-`redirect:` as a more concise way to trigger a client redirect [<<mvc:redirect>>]. 
+Given the popularity of the POST-redirect-GET pattern,
+[tck-testable tck-id-redirect-prefix]#MVC implementations are REQUIRED to support view paths prefixed by `redirect:` as a more concise way to trigger a client redirect#.
 Using this prefix, the controller shown above can be re-written as follows:
 
 [source,java,numbered]
@@ -143,19 +144,18 @@ public String redirect() {
 }
 ----
 
-In either case, relative paths are resolved relative to the JAX-RS application path - for more information please refer to the Javadoc for the `seeOther` method.
-It is worth noting that redirects require client cooperation (all browsers support it, but certain CLI clients may not) 
-and result in a completely new request-response cycle in order to access the intended controller.
-If a controller returns a `redirect:` view path, MVC implementations SHOULD use the 303 (See other) status code for the redirect, but MAY prefer 302 (Found) if HTTP 1.0 compatibility is required.
+[tck-testable tck-id-redirect-relative]#In either case, relative paths are resolved relative to the JAX-RS application path# - for more information please refer to the Javadoc for the `seeOther` method.
+It is worth noting that redirects require client cooperation (all browsers support it, but certain CLI clients may not) and result in a completely new request-response cycle in order to access the intended controller.
+If a controller returns a `redirect:` view path, [tck-testable tck-id-redirect-303-302]#MVC implementations SHOULD use the 303 (See other) status code for the redirect, but MAY prefer 302 (Found) if HTTP 1.0 compatibility is required.#
 
 MVC applications can leverage CDI by defining beans in scopes such as request and session. 
-A bean in request scope is available only during the processing of a single request, while a bean in session scope is
-available throughout an entire web session which can potentially span tens or even hundreds of requests.
+[tck-testable tck-id-scope-request]#A bean in request scope is available only during the processing of a single request#,
+[tck-testable tck-id-scope-session]#while a bean in session scope is available throughout an entire web session which can potentially span tens or even hundreds of requests#.
 
 Sometimes it is necessary to share data between the request that returns a redirect instruction and the new request that is triggered as a result. 
 That is, a scope that spans at most two requests and thus fits between a request and a session scope. 
 For this purpose, the MVC API defines a new CDI scope identified by the annotation `@RedirectScoped`.
-CDI beans in this scope are automatically created and destroyed by correlating a redirect and the request that follows. 
+[tck-testable tck-id-scope-redirect]#CDI beans in this scope are automatically created and destroyed by correlating a redirect and the request that follows#.
 The exact mechanism by which requests are correlated is implementation dependent, but popular techniques include URL rewrites and cookies.
 
 Let us assume that `MyBean` is annotated by `@RedirectScoped` and given the name `mybean`, and consider the following controller:
@@ -191,9 +191,9 @@ Models
 ~~~~~~
 
 MVC controllers are responsible for combining data models and views (templates) to produce web application pages. 
-This specification supports two kinds of models: the first is based on CDI `@Named` beans, 
+This specification supports two kinds of models: the first is based on CDI `@Named` beans,
 and the second on the `Models` interface which defines a map between names and objects.
-MVC provides view engines for JSP and Facelets out of the box, which support both types.
+[tck-testable tck-id-buildin-both-models]#MVC provides view engines for JSP and Facelets out of the box, which support both types#.
 For all other view engines supporting the `Models` interface is mandatory,
 support for CDI `@Named` beans is OPTIONAL but highly RECOMMENDED.
 
@@ -219,7 +219,7 @@ public class Greeting {
 }
 ----
 
-Given that the view engine for JSPs supports `@Named` beans, all the controller needs to do is fill out the model and return the view. 
+[tck-testable tck-id-cdi-model-inject]#Given that the view engine for JSPs supports `@Named` beans, all the controller needs to do is fill out the model and return the view#.
 Access to the model is straightforward using CDI injection:
 
 [source,java,numbered]
@@ -239,9 +239,9 @@ public class HelloController {
 }
 ----
 
-This will allow the view to access the greeting using the EL expression `${hello.greeting}`.
+[tck-testable tck-id-cdi-model-el]#This will allow the view to access the greeting using the EL expression# `${hello.greeting}`.
 
-Instead of using CDI beans annotated with `@Named`, controllers can also use the `Models` map to pass data to the view:
+Instead of using CDI beans annotated with `@Named`, [tck-testable tck-id-models-inject]#controllers can also use the `Models` map to pass data to the view#:
 
 [source,java,numbered]
 ----
@@ -286,7 +286,7 @@ Here is the JSP page for the hello-world example:
 </html>
 ----
 
-In a JSP, model properties are accessible via EL [<<el30,6>>]. In the example above, the property `message` is read from the `greeting` model 
+[tck-testable tck-id-jsp-el]#In a JSP, model properties are accessible via EL# [<<el30,6>>]. In the example above, the property `message` is read from the `greeting` model
 whose name was either specified in a `@Named` annotation or used as a key in the `Models` map, depending on which controller from the <<models>> section triggered this view's processing.
 
 Here is the corresponding example using Facelets instead of JSP:
@@ -336,7 +336,7 @@ public class BookController {
 ----
 
 Assuming the application is deployed with the context path `/myapp` and is using the application path `/mvc`,
-URIs for these controller methods can be created with an EL expression like this:
+[tck-testable tck-id-el-access]#URIs for these controller methods can be created with an EL expression# like this:
 
 [source,html]
 ----
@@ -347,16 +347,16 @@ ${mvc.uri('BookController#list')}
 ${mvc.uri('BookController#detail', { 'isbn': 1234 })}
 ----
 
-The controller method is referenced using the simple name of the controller class and the corresponding method name separated by `#`.
-If the URI contains path, query or matrix parameters, concrete values can be supplied using a map.
+[tck-testable tck-id-class-method-name]#The controller method is referenced using the simple name of the controller class and the corresponding method name# separated by `\#`.
+[tck-testable tck-id-map]#If the URI contains path, query or matrix parameters, concrete values can be supplied using a map#.
 Please note that the keys of this map must match the parameter name used in the `@PathParam`, `@QueryParam` or `@MatrixParam` annotation.
-MVC implementations MUST apply the corresponding URI encoding rules depending on whether the value is used in a query, path or matrix parameter.
+[tck-testable tck-id-uri-encoding]#MVC implementations MUST apply the corresponding URI encoding rules depending on whether the value is used in a query, path or matrix parameter#.
 
 The syntax used above to reference the controller method works well in most cases.
 However, because of the simple nature of this reference style, it will require controller class names to be unique.
 Also, the references may break if the controller class or method name changes as part of a refactoring.
 
-Therefore, applications can use the `@UriRef` annotation to define a stable and unique name for a controller method.
+[tck-testable tck-id-uri-ref]#Therefore, applications can use the `@UriRef` annotation to define a stable and unique name for a controller method#.
 
 [source,java,numbered]
 ----

--- a/spec/src/main/xsl/tck-audit.xsl
+++ b/spec/src/main/xsl/tck-audit.xsl
@@ -204,9 +204,9 @@
 
         <assertion>
             <xsl:choose>
-                <xsl:when test="contains(@role, 'test-id-')">
+                <xsl:when test="contains(@role, 'id-')">
                     <xsl:variable name="cutLeftPart">
-                        <xsl:value-of select="substring-after(@role, 'test-id-')"/>
+                        <xsl:value-of select="substring-after(@role, 'id-')"/>
                     </xsl:variable>
                     <xsl:attribute name="id">
                         <xsl:value-of select="substring-before(concat($cutLeftPart, ' '), ' ')"/>


### PR DESCRIPTION
This PR adds `[tck-testable]` annotations to chapter 2 of the specification. The chapter now contains 32 assertions we need to test in the TCK. A lot of work. :smile: 

A few notes:
* I also reformatted some of the paragraphs to match the "one sentence per line" pattern.
* I renamed the `[tck-test-id-FOOBAR]` annotation to `[tck-id-FOOBAR]` so it gets a bit shorter.
* I removed the old assertion references pointing to the Assertions chapter. I think we can remove the Assertions chapter in the end because our new assertion tracking is much better.
* I compared the old and the new PDF file and it looks like I broke nothing. Just the old assertion references were removed.

I will start implementing the first TCK tests for this chapter in the next days. Just to get a feeling for how many TCK tests per hour I can write. :laughing: 
