### PR TITLE
Allow @MvcBinding on methods

### DIFF
--- a/api/src/main/java/javax/mvc/binding/MvcBinding.java
+++ b/api/src/main/java/javax/mvc/binding/MvcBinding.java
@@ -45,7 +45,7 @@ import java.lang.annotation.Target;
  * @since 1.0
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
 @Documented
 public @interface MvcBinding {}
 


### PR DESCRIPTION
All the `@*Param` annotations of JAX-RS support placing annotations on fields, methods and parameters. But MVC only supports `@MvcBinding` on fields and parameters.

I think back then I just missed including methods in the `@Target` annotation. Therefore, I'm adding `ElementType.METHOD` in this pull request.

Please also see the relevant discussion here:

https://groups.google.com/forum/#!topic/jsr371-users/7BVK4hAsips