### PR TITLE
Added TCK annotations to 'Events' chapter

### DIFF
--- a/spec/src/main/asciidoc/chapters/assertions.asciidoc
+++ b/spec/src/main/asciidoc/chapters/assertions.asciidoc
@@ -10,9 +10,6 @@ List of all Assertions
 [[mvc:validation-result]]
 *\[[mvc:validation-result]]* If validation fails, controller methods must still be called if a `ValidationResult` field or property is defined.
 
-[[mvc:event-firing]]
-*\[[mvc:event-firing]]* All events in `javax.mvc.event` must be fired. See Javadoc for more information on each event in that package.
-
 [[mvc:builtin-engines]]
 *\[[mvc:builtin-engines]]* Implementations must provide support for JSPs and Facelets.
 

--- a/spec/src/main/asciidoc/chapters/events.asciidoc
+++ b/spec/src/main/asciidoc/chapters/events.asciidoc
@@ -2,19 +2,19 @@
 Events
 ------
 
-This chapter introduces a mechanism by which MVC applications can be informed of important events that occur while processing a request. This
-mechanism is based on CDI events that can be fired by implementations and observed by applications.
+This chapter introduces a mechanism by which MVC applications can be informed of important events that occur while processing a request.
+This mechanism is based on CDI events that can be fired by implementations and observed by applications.
 
 [[observers]]
 Observers
 ~~~~~~~~~
 
-The package `javax.mvc.event` defines a number of event types that MUST be fired by implementations during the processing of a request [<<mvc:event-firing>>]. Implementations MAY
-extend this set and also provide additional information on any of the events defined by this specification. The reader is referred to the
-implementation’s documentation for more information on event support.
+The package `javax.mvc.event` defines a number of event types that MUST be fired by implementations during the processing of a request.
+Implementations MAY extend this set and also provide additional information on any of the events defined by this specification.
+The reader is referred to the implementation’s documentation for more information on event support.
 
-Observing events can be useful for applications to learn about the lifecycle of a request, perform logging, monitor performance, etc. The
-events `BeforeControllerEvent` and `AfterControllerEvent` are fired around the invocation of a controller.
+Observing events can be useful for applications to learn about the lifecycle of a request, perform logging, monitor performance, etc.
+[tck-testable tck-id-before-after-controller]#The events `BeforeControllerEvent` and `AfterControllerEvent` are fired around the invocation of a controller#.
 
 [source,java,numbered]
 ----
@@ -44,15 +44,15 @@ public class EventObserver {
 }
 ----
 
-Observer methods in CDI are defined using the `@Observes` annotation on a parameter position. The class `EventObserver` is a CDI bean in application scope whose
-methods `onBeforeController` and `onAfterController` are called before and after a controller is called.
+Observer methods in CDI are defined using the `@Observes` annotation on a parameter position.
+The class `EventObserver` is a CDI bean in application scope whose methods `onBeforeController` and `onAfterController` are called before and after a controller is called.
 
-Every event generated must include a unique ID whose getter is defined in `MvcEvent`, the base type for all events. Moreover, each event includes
-additional information that is specific to the event; for example, the events shown in the example above allow applications to get information
-about the request URI and the resource (controller) selected.
+[tck-testable tck-id-event-id]#Every event generated must include a unique ID whose getter is defined in `MvcEvent`#, the base type for all events.
+Moreover, each event includes additional information that is specific to the event;
+for example, the events shown in the example above allow applications to get information about the request URI and the resource (controller) selected.
 
-The <<view_engines>> section describes the algorithm used by implementations to select a specific view engine for processing; after a view engine is
-selected, the method `processView` is called. The events `BeforeProcessViewEvent` and `AfterProcessViewEvent` are fired around this call.
+The <<view_engines>> section describes the algorithm used by implementations to select a specific view engine for processing; after a view engine is selected, the method `processView` is called.
+[tck-testable tck-id-before-after-view]#The events `BeforeProcessViewEvent` and `AfterProcessViewEvent` are fired around this call#.
 
 [source,java,numbered]
 ----
@@ -81,8 +81,9 @@ public class EventObserver {
 }
 ----
 
-To complete the example, let us assume that the information about the selected view engine needs to be conveyed to the client. To ensure that
-this information is available to a view returned to the client, the `EventObserver` class can inject and update the same request-scope bean accessed by such a view:
+To complete the example, let us assume that the information about the selected view engine needs to be conveyed to the client.
+To ensure that this information is available to a view returned to the client,
+the `EventObserver` class can inject and update the same request-scope bean accessed by such a view:
 
 [source,java,numbered]
 ----
@@ -102,18 +103,18 @@ public class EventObserver {
 
 For more information about the interaction between views and models, the reader is referred to the <<models>> section.
 
-The last event supported by MVC is `ControllerRedirectEvent`, which is fired just before the MVC implementation returns a redirect status code.
-Please note that this event MUST be fired after `AfterControllerEvent`.
+[tck-testable tck-id-redirect-event]#The last event supported by MVC is `ControllerRedirectEvent`, which is fired just before the MVC implementation returns a redirect status code#.
+[tck-testable tck-id-redirect-after-controller-event]#Please note that this event MUST be fired after `AfterControllerEvent`#.
 
 [source,java,numbered]
 ----
 include::{mvc-api-source-dir}javax/mvc/event/ControllerRedirectEvent.java[lines=20..-1]
 ----
 
-CDI events fired by implementations are _synchronous_, so it is recommended that applications carry out only simple tasks in their
-observer methods, avoiding long-running computations as well as blocking calls. For a complete list of events, the reader is referred to the
-Javadoc for the `javax.mvc.event` package.
+CDI events fired by implementations are _synchronous_, so it is recommended that applications carry out only simple tasks in their observer methods,
+avoiding long-running computations as well as blocking calls.
+For a complete list of events, the reader is referred to the Javadoc for the `javax.mvc.event` package.
 
-Event reporting requires the MVC implementations to create event objects before firing. In high-throughput systems without any observers the
-number of unnecessary objects created may not be insignificant. For this reason, it is RECOMMENDED for implementations to consider smart firing
-strategies when no observers are present.
+Event reporting requires the MVC implementations to create event objects before firing.
+In high-throughput systems without any observers the number of unnecessary objects created may not be insignificant.
+For this reason, it is RECOMMENDED for implementations to consider smart firing strategies when no observers are present.


### PR DESCRIPTION
This PR adds `[tck-testable]` annotations to the "Events" chapter. I also improved the formatting a bit so we have basically one sentence per line.

Please let me know if you have any objections.

