### PR TITLE
Removed Servlet related text from application chapter

### DIFF
--- a/spec/src/main/asciidoc/chapters/applications.asciidoc
+++ b/spec/src/main/asciidoc/chapters/applications.asciidoc
@@ -15,9 +15,6 @@ also applies to an MVC application. Some MVC applications may be _hybrid_ and in
 The controllers and providers that make up an application are configured via an application-supplied subclass of `Application` from JAX-RS. An implementation 
 MAY provide alternate mechanisms for locating controllers, but as in JAX-RS, the use of an `Application` subclass is the only way to guarantee portability.
 
-All the rules described in the Servlet section of the http://jcp.org/en/jsr/detail?id=339[JAX-RS Specification] [<<jaxrs20,5>>] apply to MVC as well. This section recommends the use of
-the Servlet 3 framework pluggability mechanism and describes its semantics for the cases in which an `Application` subclass is present and absent. 
-
 The path in the application's URL space in which MVC controllers live must be specified either using the `@ApplicationPath` annotation on the application
 subclass or in the web.xml as part of the `url-pattern` element. MVC applications SHOULD use a non-empty path or pattern: i.e., _"/"_ or _"/*"_ 
 should be avoided whenever possible. 


### PR DESCRIPTION
The "Applications" chapter contains a paragraph which points to the "Servlet" section of the JAX-RS spec. I think this paragraph was written at a time when MVC was requiring a Servlet environment and had explicit dependencies on the Servlet API.

However, we changed that and today MVC doesn't have any API dependency on the Servlet API. Therefore, I think it is safe to remove this paragraph. The previous paragraph already mentions the Application subclass and everything else is already defined by the JAX-RS spec.

Thoughts?