### PR TITLE
MvcContext should be request scoped

### DIFF
--- a/spec/src/main/asciidoc/chapters/applications.asciidoc
+++ b/spec/src/main/asciidoc/chapters/applications.asciidoc
@@ -32,7 +32,7 @@ MVC Context
 ~~~~~~~~~~~
 
 MVC applications can inject an instance of `MvcContext` to access configuration, security and path-related information. Instances of `MvcContext` are provided
-by implementations and are always in application scope [<<mvc:mvc-context>>]. 
+by implementations and are always in request scope [<<mvc:mvc-context>>].
 For convenience, the `MvcContext` instance is also available using the name `mvc` in EL.
 
 As an example, a view can refer to a CSS file by using the context path available in the `MvcContext` object as follows:

--- a/spec/src/main/asciidoc/chapters/assertions.asciidoc
+++ b/spec/src/main/asciidoc/chapters/assertions.asciidoc
@@ -35,7 +35,7 @@ List of all Assertions
 *\[[mvc:annotation-inheritance]]* Annotation inheritance is derived from JAX-RS and extended to MVC annotations.
 
 [[mvc:mvc-context]]
-*\[[mvc:mvc-context]]* Application-scoped `MvcContext` available for injection and as `mvc` in EL.
+*\[[mvc:mvc-context]]* Request-scoped `MvcContext` available for injection and as `mvc` in EL.
 
 [[mvc:request-locale-context]]
 *\[[mvc:request-locale-context]]* The `MvcContext` must provide access to the current request locale.


### PR DESCRIPTION
The spec currently states that `MvcContext` must be application scoped. But that's not correct. We changed this to request scope quite some time ago to support `MvcContext#getLocale()`.