### PR TITLE
Some corrections for the 'View Engines' chapter

### DIFF
--- a/spec/src/main/asciidoc/chapters/engines.asciidoc
+++ b/spec/src/main/asciidoc/chapters/engines.asciidoc
@@ -32,15 +32,13 @@ Implementations should perform the following steps while trying to find a suitab
 . Lookup all instances of `javax.mvc.engine.ViewEngine` available via CDI. footnote:[The `@Any` annotation in CDI can be used for this purpose.]
 . Call `supports` on every view engine found in the previous step, discarding those that return `false`.
 . If the resulting set is empty, return `null`.
-. Otherwise, sort the resulting set in descending order of priority using the integer value from the `@Priority` annotation decorating the view engine class +
-or the default value `Priorities.DEFAULT` if the annotation is not present.
+. Otherwise, sort the resulting set in descending order of priority using the integer value from the `@Priority` annotation decorating the view engine class or the default value `Priorities.DEFAULT` if the annotation is not present.
 . Return the first element in the resulting sorted set, that is, the view engine with the highest priority that supports the given view.
 
-If a view engine that can process a view is not found, as a fall-back attempt to process the view by other means, implementations are REQUIRED to forward
-the request-response pair back to the Servlet container using a `RequestDispatcher` [<<mvc:request-forward>>].
+If a view engine that can process a view is not found, implementations are REQUIRED to throw a `ViewEngineException`.
 
 The `processView` method has all the information necessary for processing in the `ViewEngineContext`, including the view, a reference to `Models`, as well as the 
-HTTP request and response from the underlying the Servlet container. Implementations MUST catch exceptions thrown during the execution of `processView`
+underlying `OutputStream` that can be used to send the result to the client. Implementations MUST catch exceptions thrown during the execution of `processView`
 and re-throw them as `ViewEngineException`’s [<<mvc:exception-wrap>>].
 
 Prior to the view render phase, all entries available in `Models` MUST be bound in such a way that they become available to the view being processed. 
@@ -48,7 +46,7 @@ The exact mechanism for this depends on the actual view engine implementation. I
 be bound by calling `HttpServletRequest.setAttribute(String, Object);` calling this method ensures access to the named models from EL expressions.
 
 A view returned by a controller method represents a path within an application archive. If the path is relative,
-does not start with "/", implementations MUST resolve view paths relative to value of `ViewEngine.DEFAULT VIEW FOLDER`, which is set to `/WEB-INF/views/`. 
+does not start with "/", implementations MUST resolve view paths relative to the view folder, which defaults to `/WEB-INF/views/`. 
 If the path is absolute, no further processing is required [<<mvc:view-resolution>>]. It is recommended to use relative paths and a location under `WEB-INF`
 to prevent direct access to views as static resources.
 


### PR DESCRIPTION
This PR contains some improvements for the View Engines chapter.

First of all: Sorry, but I forgot to split the changes into multiple commits. I'll summarize the changes in the order matching the file structure.

* Fixed minor layout issue. One of the list items which describes the view selection algorithm contained a newline.
* Currently the spec states that MVC implementations should simply forward request if no view engine is found for the view name returned from the controller. IMO this is very weird behavior. Usually this will lead to a 404 Not Found error if you misspell the view name which is very difficult to debug. I think we can demand that there is a view engine for all view languages and therefore must not provide this fallback behavior. I changed the text so that implementations are required to throw an exception if no view engine can be found for a given view name.
* The text mentioned that the view engine has access to the `HttpServletRequest` and `HttpServletResponse` which isn't the case any more. I corrected that.
* IMO text regarding relative view names was a bit weird as it referred to the default view folder directly. I changed that text so that it is more obvious that `/WEB-INF/view` is only a default that can be changed.

So sorry again for having all these changes in a single commit. Please let me know what you think. Any objections with merging this? Please note that the second change is a change that also requires a modification of Ozark. So please let me know if you agree to the new handling of this case.