### PR TITLE
Added TCK annotations to 'View Engines' chapter

### DIFF
--- a/spec/src/main/asciidoc/chapters/assertions.asciidoc
+++ b/spec/src/main/asciidoc/chapters/assertions.asciidoc
@@ -10,24 +10,6 @@ List of all Assertions
 [[mvc:validation-result]]
 *\[[mvc:validation-result]]* If validation fails, controller methods must still be called if a `ValidationResult` field or property is defined.
 
-[[mvc:builtin-engines]]
-*\[[mvc:builtin-engines]]* Implementations must provide support for JSPs and Facelets.
-
-[[mvc:extension-engines]]
-*\[[mvc:extension-engines]]* CDI beans that implement `javax.mvc.engine.ViewEngine` provide an ex- tension mechanism for view engines.
-
-[[mvc:selection-algorithm]]
-*\[[mvc:selection-algorithm]]* Implementations must use algorithm in the <<selection_algorithm>> section to select view engines.
-
-[[mvc:request-forward]]
-*\[[mvc:request-forward]]* Forward request for which no view engine is found.
-
-[[mvc:exception-wrap]]
-*\[[mvc:exception-wrap]]* Exceptions thrown during view processing must be wrapped.
-
-[[mvc:view-resolution]]
-*\[[mvc:view-resolution]]* Relative paths to views must be resolved as explained in the <<selection_algorithm>> section.
-
 [[mvc:null-controllers]]
 *\[[mvc:null-controllers]]* The `@View` annotation is treated as a default value for any controller method that returns a null value.
 

--- a/spec/src/main/asciidoc/chapters/engines.asciidoc
+++ b/spec/src/main/asciidoc/chapters/engines.asciidoc
@@ -2,8 +2,8 @@
 View Engines
 ------------
 
-This chapter introduces the notion of a view engine as the mechanism by which views are processed in MVC. The set of available view engines is
-extensible via CDI, enabling applications as well as other frameworks to provide support for additional view languages.
+This chapter introduces the notion of a view engine as the mechanism by which views are processed in MVC. 
+The set of available view engines is extensible via CDI, enabling applications as well as other frameworks to provide support for additional view languages.
 
 [[view_engines_introduction]]
 Introduction
@@ -12,9 +12,9 @@ Introduction
 A _view engine_ is responsible for processing views. In this context, processing entails (i) locating and loading a view (ii) preparing any
 required models and (iii) rendering the view and writing the result back to the client.
 
-Implementations MUST provide built-in support for JSPs and Facelets view engines [<<mvc:builtin-engines>>]. Additional engines may be supported via an extension mechanism
-based on CDI. Namely, any CDI bean that implements the `javax.mvc.engine.ViewEngine` interface MUST be considered as a possible target for processing by calling its 
-`supports` method, discarding the engine if this method returns `false` [<<mvc:extension-engines>>].
+[tck-testable tck-id-jsp-facelets]#Implementations MUST provide built-in support for JSPs and Facelets view engines#. 
+Additional engines may be supported via an extension mechanism based on CDI. 
+[tck-testable tck-id-cdi-discovery]#Namely, any CDI bean that implements the `javax.mvc.engine.ViewEngine` interface MUST be considered as a possible target for processing by calling its `supports` method, discarding the engine if this method returns `false`#.
 
 This is the interface that must be implemented by all MVC view engines:
 
@@ -27,35 +27,34 @@ include::{mvc-api-source-dir}javax/mvc/engine/ViewEngine.java[lines=18..-1]
 Selection Algorithm
 ~~~~~~~~~~~~~~~~~~~
 
-Implementations should perform the following steps while trying to find a suitable view engine for a view [<<mvc:selection-algorithm>>].
+[tck-testable tck-id-selection-algo]#Implementations should perform the following steps while trying to find a suitable view engine for a view#.
 
-. Lookup all instances of `javax.mvc.engine.ViewEngine` available via CDI. footnote:[The `@Any` annotation in CDI can be used for this purpose.]
+. Lookup all instances of `javax.mvc.engine.ViewEngine` available via CDI.
 . Call `supports` on every view engine found in the previous step, discarding those that return `false`.
 . If the resulting set is empty, return `null`.
 . Otherwise, sort the resulting set in descending order of priority using the integer value from the `@Priority` annotation decorating the view engine class or the default value `Priorities.DEFAULT` if the annotation is not present.
 . Return the first element in the resulting sorted set, that is, the view engine with the highest priority that supports the given view.
 
-If a view engine that can process a view is not found, implementations are REQUIRED to throw a `ViewEngineException`.
+[tck-testable tck-id-no-engine-found]#If a view engine that can process a view is not found, implementations are REQUIRED to throw a `ViewEngineException`#.
 
-The `processView` method has all the information necessary for processing in the `ViewEngineContext`, including the view, a reference to `Models`, as well as the 
-underlying `OutputStream` that can be used to send the result to the client. Implementations MUST catch exceptions thrown during the execution of `processView`
-and re-throw them as `ViewEngineException`’s [<<mvc:exception-wrap>>].
+The `processView` method has all the information necessary for processing in the `ViewEngineContext`, including the view, a reference to `Models`, as well as the underlying `OutputStream` that can be used to send the result to the client. 
+[tck-testable tck-id-engine-exception]#Implementations MUST catch exceptions thrown during the execution of `processView` and re-throw them as `ViewEngineException`’s#.
 
 Prior to the view render phase, all entries available in `Models` MUST be bound in such a way that they become available to the view being processed. 
-The exact mechanism for this depends on the actual view engine implementation. In the case of the built-in view engines for JSPs and Facelets, entries in `Models` must
-be bound by calling `HttpServletRequest.setAttribute(String, Object);` calling this method ensures access to the named models from EL expressions.
+The exact mechanism for this depends on the actual view engine implementation. 
+[tck-testable tck-id-models-binding]#In the case of the built-in view engines for JSPs and Facelets, entries in `Models` must be bound by calling `HttpServletRequest.setAttribute(String, Object)`#.
+Calling this method ensures access to the named models from EL expressions.
 
-A view returned by a controller method represents a path within an application archive. If the path is relative,
-does not start with "/", implementations MUST resolve view paths relative to the view folder, which defaults to `/WEB-INF/views/`. 
-If the path is absolute, no further processing is required [<<mvc:view-resolution>>]. It is recommended to use relative paths and a location under `WEB-INF`
-to prevent direct access to views as static resources.
+A view returned by a controller method represents a path within an application archive. 
+[tck-testable tck-id-path-relative]#If the path is relative, does not start with `/`, implementations MUST resolve view paths relative to the view folder, which defaults to `/WEB-INF/views/`#. 
+[tck-testable tck-id-path-absolute]#If the path is absolute, no further processing is required#. 
+It is recommended to use relative paths and a location under `WEB-INF` to prevent direct access to views as static resources.
 
 [[faces_servlet]]
 FacesServlet
 ~~~~~~~~~~~~
 
-Because Facelets support is not enabled by default, MVC applications that use Facelets are required to package a `web.xml` deployment descriptor with 
-the following entry mapping the extension `*.xhtml` as shown next:
+Because Facelets support is not enabled by default, MVC applications that use Facelets are required to package a `web.xml` deployment descriptor with the following entry mapping the extension `*.xhtml` as shown next:
 
 [source,xml,numbered]
 ----


### PR DESCRIPTION
This PR adds the `[tck-testable]` annotations to the "View Engines" chapter. I also cleaned up the formatting a bit. Let me know what you think!