### PR TITLE
Removed getContextPath and getApplicationPath from MvcContext

### DIFF
--- a/api/src/main/java/javax/mvc/MvcContext.java
+++ b/api/src/main/java/javax/mvc/MvcContext.java
@@ -50,41 +50,9 @@ public interface MvcContext {
     Configuration getConfig();
 
     /**
-     * <p>Get the application's context path. The value returned must be normalized
-     * to start with a slash ({@code '/'}) but not end with one. Thus, the path returned by
-     * this method can be prepended to that returned by {@link #getApplicationPath()}.</p>
-     *
-     * <p>For example, given the URI {@code http://host:port/myapp/resources/hello},
-     * this method returns {@code /myapp}.</p>
-     *
-     * @return the application's context path.
-     */
-    String getContextPath();
-
-    /**
-     * <p>Get the application's path which was set using the {@link javax.ws.rs.ApplicationPath}
-     * annotation. The value returned must be normalized to start with a slash ({@code '/'}) but
-     * not end with one. Thus, the path returned by this method can be appended to that
-     * returned by {@link #getContextPath()}.</p>
-     *
-     * <p>If the application path is empty or was set to {@code /*}, then an empty string is
-     * returned to ensure concatenation with {@link #getContextPath()} results in a well-formed
-     * path. If a JAX-RS application subclass is not found, {@code null} may be returned.</p>
-     *
-     * <p>For example, given the URI {@code http://host:port/myapp/resources/hello},
-     * this method returns {@code /resources}.</p>
-     *
-     * @return the application's path or {@code null} if not found.
-     */
-    String getApplicationPath();
-
-    /**
      * <p>Get the application's base path which is defined as the concatenation of context
      * and application paths. It follows that the value returned by this method always
      * starts with a slash but never ends with one.</p>
-     *
-     * <p>If a JAX-RS application subclass is not found, causing {@link #getApplicationPath()}
-     * to return {@code null}, then the value returned is the same as {@link #getContextPath}.</p>
      *
      * @return the application's base path.
      */

--- a/spec/src/main/asciidoc/chapters/applications.asciidoc
+++ b/spec/src/main/asciidoc/chapters/applications.asciidoc
@@ -29,11 +29,11 @@ MVC Context
 [tck-testable tck-id-request-scope]#Instances of `MvcContext` are provided by implementations and are always in request scope#.
 [tck-testable tck-id-el-access]#For convenience, the `MvcContext` instance is also available using the name `mvc` in EL#.
 
-As an example, a view can refer to a CSS file by using the context path available in the `MvcContext` object as follows:
+As an example, a view can refer to a controller by using the base path available in the `MvcContext` object as follows:
 
 [source,html]
 ----
-<link rel="stylesheet" type="text/css" href="${mvc.contextPath}/my.css">
+<a href="${mvc.basePath}/books">Click here</a>
 ----
 
 For more information on security see the Chapter on <<security,Security>>; for more information about the `MvcContext` in general, refer to the Javadoc for the type.


### PR DESCRIPTION
There was recently some discussion whether we really need three `MvcContext#get*Path()` methods. See #151 for details.

This pull request will remove both `getContextPath()` and `getApplicationPath()` from the `MvcContext` class. Please see the following list for arguments against these methods:

* `getContextPath()`
  * In JSP and Facelets `${mvc.contextPath}` can be replaced with `${request.contextPath}`. So we really don't need an additional way to get the context path.
  * For 3rd party view engines which don't provide a native way to access the `HttpServletRequest`, the view engine implementation can simply store the request in the model: `model.put("request", request)`. This way 3rd party view engines can access the context path the same way as JSP/Facelets.
  * We spent some time to get rid of the explicit API dependency on Servlet. The *context path* is actually part of the Servlet specification. So exposing it via `MvcContext` creates some kind of implicit dependency on Servlet.
* `getApplicationPath()`
  * The raw application path (without the context path prefix) isn't useful at all. If you want to build an absolute path in the view, you either need the context path (for static assets like images and CSS files) or the base path (context path + application path) which you get via `${mvc.basePath}`

Please review this pull request and approve it if you agree to those changes.