### PR TITLE
fix font-size source. Issue#152

### DIFF
--- a/spec/src/main/asciidoc/spec.asciidoc
+++ b/spec/src/main/asciidoc/spec.asciidoc
@@ -10,6 +10,7 @@ Version 1.0 Public Review, December 2017
 :sectnums:
 :toc:
 :toclevels: 3
+:autofit-option:
 ifdef::backend-pdf[]
 :sectanchors:
 :doctype: book


### PR DESCRIPTION
#152 

This PR fix the font-size source in SPEC in mode global using attribute 

> :autofit-option:

https://github.com/asciidoctor/asciidoctor-pdf

![fix](https://user-images.githubusercontent.com/8139890/40561087-4ab8f526-6032-11e8-88bb-4eeee9f28df1.png)

pdf attached :   

[spec.pdf](https://github.com/mvc-spec/mvc-spec/files/2040552/spec.pdf)
