### PR TITLE
Add BindingError#getSubmittedValue method

### DIFF
--- a/api/src/main/java/javax/mvc/binding/BindingError.java
+++ b/api/src/main/java/javax/mvc/binding/BindingError.java
@@ -41,4 +41,12 @@ public interface BindingError {
      */
     String getParamName();
 
+    /**
+     * Provides access to the raw submitted value of the parameter which caused the
+     * binding to fail.
+     *
+     * @return The raw value submitted for the parameter
+     */
+    String getSubmittedValue();
+
 }


### PR DESCRIPTION
I think it would be really useful if the `BindingError` class would provide to the raw submitted value which caused the binding to fail. Basically this would be the value the user entered into the form field but which could not (for whatever reason) be bound to the corresponding property/parameter.