### PR TITLE
fix - small adjust in annotations.asciidoc .

### DIFF
--- a/spec/src/main/asciidoc/chapters/annotations.asciidoc
+++ b/spec/src/main/asciidoc/chapters/annotations.asciidoc
@@ -39,6 +39,6 @@ token results in a `ForbiddenException` thrown.
 |`MvcBinding`
 |Field, method or parameter
 |Declares that constraint violations will be handled by a
-|controller through `BindingResult` instead of triggering
-|a `ConstraintViolationException`.
+controller through `BindingResult` instead of triggering
+a `ConstraintViolationException`.
 |===


### PR DESCRIPTION
- a small adjust in annotations.asciidoc in section MvcBinding . In form original, the is  text broke .

