### PR TITLE
Fixed encoding warning in Maven build

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -47,6 +47,7 @@
     </mailingLists>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 


### PR DESCRIPTION
The build currently emits warning like:

    [WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!

This PR adds the `project.build.sourceEncoding` property to fix this problem.