### PR TITLE
Some minor corrections for the ViewEngine API docs

### DIFF
--- a/api/src/main/java/javax/mvc/engine/ViewEngine.java
+++ b/api/src/main/java/javax/mvc/engine/ViewEngine.java
@@ -17,7 +17,7 @@ package javax.mvc.engine;
 
 /**
  * <p>View engines are responsible for processing views and are discovered
- * using CDI. Implementations must inject all instances of this interface,
+ * using CDI. Implementations must look up all instances of this interface,
  * and process a view as follows:
  * <ol>
  *     <li>Gather the set of candidate view engines by calling {@link #supports(String)}
@@ -45,8 +45,7 @@ package javax.mvc.engine;
 public interface ViewEngine {
 
     /**
-     * Name of property that can be set in an application's {@link javax.ws.rs.core.Configuration}
-     * to override the root location for views in an archive.
+     * Name of property that can be set to override the root location for views in an archive.
      *
      * @see javax.ws.rs.core.Application#getProperties()
      */


### PR DESCRIPTION
This pull request contains two minor improvements for the `ViewEngine` API docs:

* The docs state that MVC implementations must **inject** `ViewEngine` instances to implement the view selection algorithm. I don't like the word **inject** here. Typically, an implementation will directly query the `BeanManager` for implementations which is technically not injection. I think that **look up** is better here.
* The spec states that MVC implementations MUST support JAX-RS configuration properties but MAY also support other source for configuration. Therefore, I think that the API docs shouldn't really mention the JAX-RS configuration mechanism explicitly. Especially mentioning the JAX-RS `Configuration` class is confusing, because people typically override `Application.getProperties()` for configuration.

It would be great to get some reviews for this one.