### PR TITLE
Extracted ParamError base interface

### DIFF
--- a/api/src/main/java/javax/mvc/binding/BindingError.java
+++ b/api/src/main/java/javax/mvc/binding/BindingError.java
@@ -24,22 +24,7 @@ package javax.mvc.binding;
  * @author Christian Kaltepoth
  * @since 1.0
  */
-public interface BindingError {
-
-    /**
-     * Returns the interpolated error message for this binding error.
-     *
-     * @return The human-readable error message
-     */
-    String getMessage();
-
-    /**
-     * The parameter name of the value that caused the binding error. This is usually
-     * the name specified with the binding annotation (i.e. {@link javax.ws.rs.FormParam}).
-     *
-     * @return The name of the parameter which caused the error
-     */
-    String getParamName();
+public interface BindingError extends ParamError {
 
     /**
      * Provides access to the raw submitted value of the parameter which caused the

--- a/api/src/main/java/javax/mvc/binding/ParamError.java
+++ b/api/src/main/java/javax/mvc/binding/ParamError.java
@@ -15,22 +15,27 @@
  */
 package javax.mvc.binding;
 
-import javax.validation.ConstraintViolation;
-
 /**
- * <p>Represents a single validation error detected for a parameter. A validation error always
- * corresponds to exactly one {@link ConstraintViolation}.</p>
+ * Base interface for errors related to parameter data binding
  *
  * @author Christian Kaltepoth
  * @since 1.0
  */
-public interface ValidationError extends ParamError {
+public interface ParamError {
 
     /**
-     * The underlying {@link ConstraintViolation} detected for the parameter.
+     * Returns a human-readable error message for this error.
      *
-     * @return The violation detected for the parameter
+     * @return The human-readable error message
      */
-    ConstraintViolation<?> getViolation();
+    String getMessage();
+
+    /**
+     * The parameter name of the value that caused the error. This is usually
+     * the name specified in the binding annotation (i.e. {@link javax.ws.rs.FormParam}).
+     *
+     * @return The name of the parameter which caused the error
+     */
+    String getParamName();
 
 }


### PR DESCRIPTION
`BindingError` and `ValidationError` both define the methods `getParamName()` and `getMessage()`.

Therefore, we should have a base interface which `BindingError` and `ValidationError` can extend. This would also allow us to simplify the `BindingResult` API later on.

I like the name `ParamError` for the base interface. However, I'm open for alternatives.