### PR TITLE
Modified Models interface to not extend Map (#40)

### DIFF
--- a/api/src/main/java/javax/mvc/Models.java
+++ b/api/src/main/java/javax/mvc/Models.java
@@ -27,9 +27,45 @@ import java.util.Map;
  * optional.
  *
  * @author Santiago Pericas-Geertsen
+ * @author Christian Kaltepoth
  * @see javax.inject.Named
  * @see javax.enterprise.context.RequestScoped
  * @since 1.0
  */
-public interface Models extends Map<String, Object>, Iterable<String> {
+public interface Models extends Iterable<String> {
+
+    /**
+     * Stores a new model in the map.
+     *
+     * @param name  name of the model
+     * @param model model to store in the map
+     * @return the current instance to allow method chaining
+     */
+    Models put(String name, Object model);
+
+    /**
+     * Retrieve a model by name.
+     *
+     * @param name name of the model
+     * @return the model or <code>null</code>
+     */
+    Object get(String name);
+
+    /**
+     * Retrieve a model by name in a type-safe way.
+     *
+     * @param name  name of the model
+     * @param clazz type of the model
+     * @param <T>   type of the model
+     * @return The model or <code>null</code>
+     */
+    <T> T get(String name, Class<T> clazz);
+
+    /**
+     * Returns a unmodifiable view of the models map.
+     *
+     * @return unmodifiable map
+     */
+    Map<String, Object> asMap();
+
 }


### PR DESCRIPTION
Hi everyone,

this pull request addresses #40. This issue came up quite early and it looked like most people did prefer to actually NOT let `Models` extend `java.util.Map`. However, the former spec leads decided back then to not change this and keep extending `Map`. I really think that we should address this now. 

Not extending `Map` and providing our own methods to modify the internal map has many benefits:

  * We have more control over the API. Especially we don't expose methods of the `Map` interface which don't make much sense for `Models`.
  * We now have a fluent `put()` method to allow method chaining.
  * We now have a type-safe `get()` method
  * 99% of the existing sample applications will still compile, because most people just use `put()`, which is defined exactly like the `Map#put()`.

Please let me know what you think. Unfortunately the old discussions regarding this issue are not available anymore because of the java.net shutdown. But you can try to search for "models map" or "MVC_SPEC-28" in your mail client.