### PR TITLE
Add javadocs for value attribute of View annotation

### DIFF
--- a/api/src/main/java/javax/mvc/View.java
+++ b/api/src/main/java/javax/mvc/View.java
@@ -49,6 +49,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Inherited
 public @interface View {
+
+    /**
+     * The name of the view
+     *
+     * @return view name
+     */
     String value();
+
 }
 


### PR DESCRIPTION
The `value` attribute of the `@View` annotation is missing API documentation.