### PR TITLE
Javadoc improvements for the javax.mvc.security package

### DIFF
--- a/api/src/main/java/javax/mvc/security/Csrf.java
+++ b/api/src/main/java/javax/mvc/security/Csrf.java
@@ -29,10 +29,8 @@ public interface Csrf {
     /**
      * Property that can be used to globally enable CSRF protection for an application.
      * Values of this property must be of type {@link Csrf.CsrfOptions}.
-     *
-     * @see javax.ws.rs.core.Application#getProperties
      */
-    static final String CSRF_PROTECTION = "javax.mvc.security.CsrfProtection";
+    String CSRF_PROTECTION = "javax.mvc.security.CsrfProtection";
 
     /**
      * Options for property {@link Csrf#CSRF_PROTECTION}.
@@ -47,13 +45,13 @@ public interface Csrf {
          */
         EXPLICIT,
         /**
-         * CSRF enabled automatically.
+         * CSRF enabled automatically for all controllers.
          */
         IMPLICIT
     };
 
     /**
-     * Returns the name of the CSRF header. This header is typically a constant.
+     * Returns the name of the CSRF form field or HTTP request header. This name is typically a constant.
      *
      * @return name of CSRF header.
      */

--- a/api/src/main/java/javax/mvc/security/CsrfValidationException.java
+++ b/api/src/main/java/javax/mvc/security/CsrfValidationException.java
@@ -17,7 +17,7 @@ package javax.mvc.security;
 
 /**
  * This exception is thrown by the MVC implementation if the CSRF token validation fails.
- * By default this will result in a 403 status code sent to the client. The application
+ * By default, this will result in a 403 status code sent to the client. The application
  * can provide a custom exception mapper for this exception type to customize this
  * default behavior.
  *

--- a/api/src/main/java/javax/mvc/security/package-info.java
+++ b/api/src/main/java/javax/mvc/security/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * Types related to Web security.
+ * Types related to MVC security features.
  *
  * @version 1.0
  */


### PR DESCRIPTION
This PR contains a few improvements for the API docs of the security package.

A few notes:
  * Using `static final` on interfaces ist redundant
  * `Csrf.getName()` was only mentioning headers, but in most cases developers will use a hidden field to submit the token.
  * "Web security" sounds weird, because MVC is all about the web. And it should be a lower case "w". I changed the wording to "MVC security features".

Let me know what you think.