### PR TITLE
Removed note about MessageBundle from BindingError docs (#59)

### DIFF
--- a/api/src/main/java/javax/mvc/binding/BindingError.java
+++ b/api/src/main/java/javax/mvc/binding/BindingError.java
@@ -17,9 +17,8 @@ package javax.mvc.binding;
 
 /**
  * <p>Represents a single error that occurred while binding a parameter to a controller
- * method argument or controller field using a binding annotation like {@link
- * javax.ws.rs.FormParam}. Binding error message templates are read from a
- * {@link java.util.ResourceBundle} named <code>BindingMessages</code>.</p>
+ * method argument or controller field using a binding annotation like 
+ * {@link javax.ws.rs.FormParam}.</p>
  *
  * @author Christian Kaltepoth
  * @since 1.0


### PR DESCRIPTION
The API docs for `BindingError` contains the following note:

> Binding error message templates are read from a `java.util.ResourceBundle` named `BindingMessages`.

There are a few problems with this:

 * I added this note back then but today I'm not sure if this was a good idea. :laughing: 
 * We would need to define keys for the various errors that can occur while processing the binding 
 * I don't know how users could overwrite the default messages. Will creating an additional bundle on the classpath work? Which one will be used if there is more than one.
 * Ozark currently doesn't support this at all.

Therefore, I would like to simply remove this sentence for now. This means that how the error text is constructed is unspecified. This will allow us to experiment with different approaches in Ozark and specify the exact handling in the spec later.