### PR TITLE
Added Andreas Badelt to the contributors list

### DIFF
--- a/spec/src/main/asciidoc/chapters/intro.asciidoc
+++ b/spec/src/main/asciidoc/chapters/intro.asciidoc
@@ -151,6 +151,8 @@ The following are the contributors of the specification:
 |===
 |Daniel Dias dos Santos
 |Phillip Krüger
+|Andreas Badelt
+|
 |===
 
 [[acks]]


### PR DESCRIPTION
Somehow we missed to add @abadelt to the spec document in the "Contributors" section. Andreas did a great job helping us with the TCK coverage report and he was approved as an official contributor quite some time ago.