### PR TITLE
Minor improvements of the ControllerRedirectEvent API docs

### DIFF
--- a/api/src/main/java/javax/mvc/event/ControllerRedirectEvent.java
+++ b/api/src/main/java/javax/mvc/event/ControllerRedirectEvent.java
@@ -20,13 +20,13 @@ import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 
 /**
- * <p>Event fired when a controller returns a redirect status code. Only the
+ * <p>Event fired when a controller triggers a redirect. Only the
  * status codes 301 (moved permanently), 302 (found), 303 (see other) and
  * 307 (temporary redirect) are REQUIRED to be reported. Note that the
  * JAX-RS methods
  * {@link javax.ws.rs.core.Response#seeOther(java.net.URI)}} and
  * {@link javax.ws.rs.core.Response#temporaryRedirect(java.net.URI)}}
- * set to the status codes to 303 and 307, respectively. Must be
+ * use the status codes to 303 and 307, respectively. Must be
  * fired after {@link javax.mvc.event.AfterControllerEvent}.</p>
  *
  * <p>For example:


### PR DESCRIPTION
This pull request contains some minor improvements of the `ControllerRedirectEvent` API docs:

  * IMO the wording "when a controller returns a redirect status code" sounds weird. What about controllers returning something like `redirect:foobar`. Such controllers don't actually return a status code, but they return a special string which results in an HTTP redirect. Perhaps the new wording is a bit better?
  * The wording "set to the status codes" sounds incorrect. Not sure if it really is. I just updated the wording a bit.

It would be great if you could approve this PR.