### PR TITLE
Remove MvcEvent#getId() method (fixes #182)

### DIFF
--- a/api/src/main/java/javax/mvc/event/MvcEvent.java
+++ b/api/src/main/java/javax/mvc/event/MvcEvent.java
@@ -23,11 +23,4 @@ package javax.mvc.event;
  */
 public interface MvcEvent {
 
-    /**
-     * A unique identifier for this event. It does not need to be universally
-     * unique nor different across application restarts.
-     *
-     * @return an event identifier.
-     */
-    String getId();
 }


### PR DESCRIPTION
This PR fixes #182 by removing the `MvcEvent.getId()` method. Please see the discussions in #182 for details.