### PR TITLE
Update ViewEngine priority constants (fixes #169)

### DIFF
--- a/api/src/main/java/javax/mvc/engine/ViewEngine.java
+++ b/api/src/main/java/javax/mvc/engine/ViewEngine.java
@@ -24,7 +24,7 @@ package javax.mvc.engine;
  *     and discarding engines that return <code>false</code>.</li>
  *     <li>Sort the resulting set of candidates using priorities. View engines
  *     can be decorated with {@link javax.annotation.Priority} to indicate
- *     their priority; otherwise the priority is assumed to be {@link ViewEngine#PRIORITY_DEFAULT}.</li>
+ *     their priority; otherwise the priority is assumed to be {@link ViewEngine#PRIORITY_APPLICATION}.</li>
  *     <li>If more than one candidate is available, choose one in an
  *     implementation-defined manner.</li>
  *     <li>Fire a {@link javax.mvc.event.BeforeProcessViewEvent} event.</li>
@@ -57,7 +57,7 @@ public interface ViewEngine {
     String DEFAULT_VIEW_FOLDER = "/WEB-INF/views/";
 
     /**
-     * Default priority for all built-in view engines.
+     * Priority for all built-in view engines.
      */
     int PRIORITY_DEFAULT = 1000;
 
@@ -68,7 +68,7 @@ public interface ViewEngine {
     int PRIORITY_FRAMEWORK = 2000;
 
     /**
-     * Recommended priority for all application-provided view engines.
+     * Recommended priority for all application-provided view engines (default).
      */
     int PRIORITY_APPLICATION = 3000;
 

--- a/api/src/main/java/javax/mvc/engine/ViewEngine.java
+++ b/api/src/main/java/javax/mvc/engine/ViewEngine.java
@@ -59,7 +59,7 @@ public interface ViewEngine {
     /**
      * Priority for all built-in view engines.
      */
-    int PRIORITY_DEFAULT = 1000;
+    int PRIORITY_BUILTIN = 1000;
 
     /**
      * Recommended priority for all view engines provided by frameworks built

--- a/spec/src/main/asciidoc/chapters/engines.asciidoc
+++ b/spec/src/main/asciidoc/chapters/engines.asciidoc
@@ -32,7 +32,7 @@ Selection Algorithm
 . Lookup all instances of `javax.mvc.engine.ViewEngine` available via CDI.
 . Call `supports` on every view engine found in the previous step, discarding those that return `false`.
 . If the resulting set is empty, return `null`.
-. Otherwise, sort the resulting set in descending order of priority using the integer value from the `@Priority` annotation decorating the view engine class or the default value `ViewEngine.PRIORITY_DEFAULT` if the annotation is not present.
+. Otherwise, sort the resulting set in descending order of priority using the integer value from the `@Priority` annotation decorating the view engine class or the default value `ViewEngine.PRIORITY_APPLICATION` if the annotation is not present.
 . Return the first element in the resulting sorted set, that is, the view engine with the highest priority that supports the given view.
 
 [tck-testable tck-id-no-engine-found]#If a view engine that can process a view is not found, implementations are REQUIRED to throw a `ViewEngineException`#.


### PR DESCRIPTION
This pull requests contains the changes to the `ViewEngine` priority constants as discusses in #169.

The changes are:
  * The default priority is now PRIORITY_APPLICATION
  * The PRIORITY_DEFAULT constant has been renamed to PRIORITY_BUILTIN
