### PR TITLE
Fire After[Controller|ProcessView]Event even in case of errors

### DIFF
--- a/api/src/main/java/javax/mvc/event/AfterControllerEvent.java
+++ b/api/src/main/java/javax/mvc/event/AfterControllerEvent.java
@@ -19,9 +19,9 @@ import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.UriInfo;
 
 /**
- * <p>Event fired after a controller returns successfully. If the controller throws
- * an exception, this event may not be fired. Must be fired after {@link
- * javax.mvc.event.BeforeControllerEvent}.</p>
+ * <p>Event fired after a controller method returns. This event is always fired,
+ * even if the controller methods fails with an exception. Must be fired after 
+ * {@link javax.mvc.event.BeforeControllerEvent}.</p>
  *
  * <p>For example:
  * <pre><code>    public class EventObserver {
@@ -31,6 +31,7 @@ import javax.ws.rs.core.UriInfo;
  *    }</code></pre>
  *
  * @author Santiago Pericas-Geertsen
+ * @author Christian Kaltepoth
  * @see javax.enterprise.event.Observes
  * @since 1.0
  */

--- a/api/src/main/java/javax/mvc/event/AfterProcessViewEvent.java
+++ b/api/src/main/java/javax/mvc/event/AfterProcessViewEvent.java
@@ -20,9 +20,8 @@ import javax.mvc.engine.ViewEngine;
 /**
  * <p>Event fired after the view engine method
  * {@link javax.mvc.engine.ViewEngine#processView(javax.mvc.engine.ViewEngineContext)}
- * returns successfully. If the an exception is thrown while processing a view,
- * this event may not be fired. Must be fired after {@link
- * javax.mvc.event.BeforeProcessViewEvent}.</p>
+ * returns. This event is always fired, even if the view engine fails with an exception. 
+ * Must be fired after {@link javax.mvc.event.BeforeProcessViewEvent}.</p>
  *
  * <p>For example:
  * <pre><code>    public class EventObserver {
@@ -32,6 +31,7 @@ import javax.mvc.engine.ViewEngine;
  *    }</code></pre>
  *
  * @author Santiago Pericas-Geertsen
+ * @author Christian Kaltepoth
  * @see javax.enterprise.event.Observes
  * @since 1.0
  */

--- a/spec/src/main/asciidoc/chapters/events.asciidoc
+++ b/spec/src/main/asciidoc/chapters/events.asciidoc
@@ -15,6 +15,7 @@ The reader is referred to the implementation’s documentation for more informat
 
 Observing events can be useful for applications to learn about the lifecycle of a request, perform logging, monitor performance, etc.
 [tck-testable tck-id-before-after-controller]#The events `BeforeControllerEvent` and `AfterControllerEvent` are fired around the invocation of a controller#.
+[tck-testable tck-id-after-controller-exception]#Please note that `AfterControllerEvent` is always fired, even if the controller fails with an exception#.
 
 [source,java,numbered]
 ----
@@ -53,6 +54,7 @@ for example, the events shown in the example above allow applications to get inf
 
 The <<view_engines>> section describes the algorithm used by implementations to select a specific view engine for processing; after a view engine is selected, the method `processView` is called.
 [tck-testable tck-id-before-after-view]#The events `BeforeProcessViewEvent` and `AfterProcessViewEvent` are fired around this call#.
+[tck-testable tck-id-after-view-exception]#Please note that `AfterProcessViewEvent` is always fired, even if the view engine fails with an exception#.
 
 [source,java,numbered]
 ----


### PR DESCRIPTION
As discussed in #125 the "after" events `AfterControllerEvent` and `AfterProcessViewEvent` should be fired even if the controller or the view engines files with an exception. This is much more consistent and allows observers to handle such cases.

The PR updates both the API docs and the spec document.