### PR TITLE
Allow building with Java 9+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: oraclejdk10
 script:
   - mvn clean install -B -V
 deploy:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -110,8 +110,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.8.0</version>
                 <configuration>
+                    <release>8</release>
                     <source>1.8</source>
                     <target>1.8</target>
                     <useIncrementalCompilation>false</useIncrementalCompilation>
@@ -218,7 +219,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.5.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
It's a bit of a hassle to always switch back to Java 8. Since version 8 goes EOL this month, we shouldn't require developerts to install potentially insecure software. 

This updates the compiler plugin to support Java 9+. It uses the javac -release Flag to produce Java 8 compatible bytecode, so things will keep working on older platforms.

I tested this with Java 10. Ozark still compiles works against the ouput compiling and running on java 8.

While the output is compatible with java 8, the build will require Java9+. JDK 1.8 will no longer work when compiling this project as it doesn't have the -release flag.