### PR TITLE
 Explicitly allow CsrfProtected on types (fixes #176)

### DIFF
--- a/api/src/main/java/javax/mvc/security/CsrfProtected.java
+++ b/api/src/main/java/javax/mvc/security/CsrfProtected.java
@@ -35,10 +35,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * for POST controllers that consume payloads of type
  * {@link javax.ws.rs.core.MediaType#APPLICATION_FORM_URLENCODED_TYPE}, but
  * other HTTP methods and payloads may be optionally supported by the
- * underlying implementation.
- *
- * <p>Even though this annotation is also targeted to {@code TYPE}, it can only be used
- * to decorate individual controller methods.</p>
+ * underlying implementation. If declared at the type level, it applies 
+ * to all methods in the type.</p>
  *
  * @author Santiago Pericas-Geertsen
  * @see javax.mvc.security.Csrf

--- a/api/src/main/java/javax/mvc/security/CsrfProtected.java
+++ b/api/src/main/java/javax/mvc/security/CsrfProtected.java
@@ -15,7 +15,6 @@
  */
 package javax.mvc.security;
 
-import javax.ws.rs.NameBinding;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -42,7 +41,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see javax.mvc.security.Csrf
  * @since 1.0
  */
-@NameBinding
 @Target({METHOD, TYPE})
 @Retention(RUNTIME)
 @Documented


### PR DESCRIPTION
This PR contains the changes proposed in #176:

 * `@CsrfProtected` should be allowed on classes and then apply to all methods
 * Removed `@NameBinding`, because it is not used in the RI and is actually an implementation concern.

Please review! 