### PR TITLE
Improved support for building on JDK9+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: java
-jdk: oraclejdk10
+jdk:
+- oraclejdk8
+- oraclejdk9
+- oraclejdk10
+- openjdk8
+- openjdk9
+- openjdk10
 script:
   - mvn clean install -B -V
 deploy:
@@ -9,6 +15,7 @@ deploy:
   on:
     repo: mvc-spec/mvc-spec
     branch: master
+    jdk: oraclejdk8
 env:
   global:
     - secure: "iJFl971N9L3Bi1+2Z8DGexI+5VObaenykZB9+xohWEKSwzRjusa6/pmzk9+1Cm7RicwDubmx5kmcJvkZki5EF5wVP7lnuHodM2d281052qq/2TcaCN3/DmyGg1QuunCDvZpVWfu1e1F5KMwmp+brt6yaUQVPVN/ehKyT++niO7ZOlhjaB2Gn02bPwW8BZ8aEUt2mNPNwSOJ7R1g4yV+Ji7lleWTIMbJCa1bmg9YncHLyCU8un5vm/fok5fcmwZwrtnckbSU2fgIo8GDXKbblsHOSC2FeYfQFhFzMjh3+bhPhKHmQN7IG4puseNhsuJHGWAzK9hXdaacl+yZ+3WvPr7jf8E4ZL2RinCLaZwxkgHiImrm9Ay9FGMckyyobaPL3Uos1T2MBkhAIle9bh7GAw8GUYbZbCz+IUESTyloQn8Tg4Nspw7xna3W5uBzYySEBgJWKDnQBuWF9HOhJTzJunNWFfLrQEOXaQkyYks5+1VzMm2kKL10hJ55TwG/9zKA7AWspdeaK53ZdtzEfuVLfLymkpKZbtp872sdHbfveV8eeRwFoD4b8TF9K5oxMDQYzeP3N3zlpFsvXtjzQoAOxRE96n/1FiYTQQvbbiTf43lW/HI4QqyA6sV897zjdX5qhnTJT6iFZWxkCgt63Acnrz+CzMdFtL8CCEXnfJi/oIbY="

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: oraclejdk10
 script:
   - mvn clean install -B -V
 deploy:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -110,8 +110,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.8.0</version>
                 <configuration>
+                    <release>8</release>
                     <source>1.8</source>
                     <target>1.8</target>
                     <useIncrementalCompilation>false</useIncrementalCompilation>
@@ -218,7 +219,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.5.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -78,6 +78,8 @@
         <spec_version>1.0</spec_version>
         <spec_impl_version>${project.version}</spec_impl_version>
         <packages.export>javax.mvc.*</packages.export>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -112,9 +114,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <release>8</release>
-                    <source>1.8</source>
-                    <target>1.8</target>
                     <useIncrementalCompilation>false</useIncrementalCompilation>
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
@@ -291,6 +290,15 @@
         </dependency>
     </dependencies>
     <profiles>
+        <profile>
+            <id>jdk9plus</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+        </profile>
         <profile>
             <id>jacoco</id>
             <build>


### PR DESCRIPTION
This pull request is basically #194 + some minor adjustments. I wasn't able to push to @gtudan's branch, so I created new pull request.

The PR will:
  * Update Travis config to run builds against all JDKs
  * Update a few plugin versions
  * Automatically set the new `release` flag for JDK9+

Kudos to @gtudan for the initial pull request.