### PR TITLE
Added missing @param Javadoc annotation

### DIFF
--- a/api/src/main/java/javax/mvc/binding/BindingResult.java
+++ b/api/src/main/java/javax/mvc/binding/BindingResult.java
@@ -67,6 +67,7 @@ public interface BindingResult {
      * Returns an immutable set of all binding and validation errors for
      * a specific parameter.
      *
+     * @param param parameter name
      * @return All binding and validation errors for the parameter.
      */
     Set<ParamError> getErrors(String param);


### PR DESCRIPTION
Sorry, I missed that one in the `BindingResult` refactoring. It causes warning during the build.