### PR TITLE
Using JAX-RS 2.1.1

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -267,7 +267,7 @@
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1</version>
+            <version>2.1.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
JAX-RS 2.1.1 was released yesterday, so MVC API should use this particular version.

Signed-off-by: Markus KARG markus@headcrashing.eu