### PR TITLE
Removed 'oraclejdk10' from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 jdk:
 - oraclejdk8
 - oraclejdk9
-- oraclejdk10
 - openjdk8
 - openjdk9
 - openjdk10


### PR DESCRIPTION
Travis doesn't support Oracle JDK 10 anymore and therefore the corresponding build fails. This PR removes `oraclejdk10` from the build config.