### PR TITLE
Updated dependencies to latest Jakarta EE versions

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -265,9 +265,9 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1.1</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>2.1.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -283,9 +283,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.1</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>1.3.4</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR updates our dependencies to the latest releases published under the new `jakarta` namespace.