### PR TITLE
Specify the name of the CSRF HTTP header (#207)

### DIFF
--- a/api/src/main/java/javax/mvc/security/Csrf.java
+++ b/api/src/main/java/javax/mvc/security/Csrf.java
@@ -21,6 +21,7 @@ package javax.mvc.security;
  * and accessible from EL via the {@link javax.mvc.MvcContext} class as {@code mvc.csrf}.
  *
  * @author Santiago Pericas-Geertsen
+ * @author Christian Kaltepoth
  * @see CsrfProtected
  * @since 1.0
  */
@@ -32,6 +33,17 @@ public interface Csrf {
      */
     String CSRF_PROTECTION = "javax.mvc.security.CsrfProtection";
 
+    /**
+     * Property that can be used to configure the name of the HTTP header used for
+     * the CSRF token.
+     */
+    String CSRF_HEADER_NAME = "javax.mvc.security.CsrfHeaderName";
+
+    /**
+     * The default value for {@link #CSRF_HEADER_NAME}.
+     */
+    String DEFAULT_CSRF_HEADER_NAME = "X-CSRF-TOKEN";
+    
     /**
      * Options for property {@link Csrf#CSRF_PROTECTION}.
      */

--- a/spec/src/main/asciidoc/chapters/applications.asciidoc
+++ b/spec/src/main/asciidoc/chapters/applications.asciidoc
@@ -68,6 +68,7 @@ There are concrete configurations, that all MVC the implementations are `REQUIRE
 
 - `ViewEngine.VIEW_FOLDER` 
 - `Csrf.CSRF_PROTECTION`
+- `Csrf.CSRF_HEADER_NAME`
 
 Here's a simple example of how you can configure a custom location for the view folder other than the `/WEB-INF/views`, simply by overwriting the `getProperties` method of the subclass `Application`:
 

--- a/spec/src/main/asciidoc/chapters/security.asciidoc
+++ b/spec/src/main/asciidoc/chapters/security.asciidoc
@@ -65,7 +65,8 @@ Another way to convey this information to and from the client is via an HTTP hea
 The application-level property `javax.mvc.security.CsrfProtection` enables CSRF protection when set to one of the possible values defined in `javax.mvc.security.Csrf.CsrfOptions`.
 [tck-testable tck-id-csrf-opt-default]#The default value of this property is `CsrfOptions.EXPLICIT`#.
 [tck-testable tck-id-csrf-inject-header]#Any other value than `CsrfOptions.OFF` will automatically inject a CSRF token as an HTTP header#.
-The actual name of this header is implementation dependent.
+[tck-testable tck-id-csrf-custom-header-name]#The actual name of the header can be configured via the `Csrf.CSRF_HEADER_NAME` configuration property#.
+[tck-testable tck-id-csrf-default-header-name]#The default name of the header is `Csrf.DEFAULT_CSRF_HEADER_NAME`#.
 
 [tck-testable tck-id-csrf-implicit]#Automatic validation is enabled by setting this property to `CsrfOptions.IMPLICIT`, in which case all post requests must include either an HTTP header or a hidden field with the correct token#.
 [tck-testable tck-id-csrf-explict]#Finally, if the property is set to `CsrfOptions.EXPLICIT` then application developers must annotate controllers using `@CsrfProtected` to manually enable validation as shown in the following example#.


### PR DESCRIPTION
This PR addresses #207. We now explicitly specify the name of the CSRF HTTP header and allow to change it via a new configuration property.