### PR TITLE
Updated EG member list

### DIFF
--- a/spec/src/main/asciidoc/chapters/intro.asciidoc
+++ b/spec/src/main/asciidoc/chapters/intro.asciidoc
@@ -120,7 +120,6 @@ This specification is being developed as part of https://jcp.org/en/jsr/detail?i
 
 [cols="1,1"] 
 |===
-|Mathieu Ancelin (Individual Member)
 |Ivar Grimstad (Individual Member)
 |Neil Griffin (Liferay, Inc)
 |Joshua Wilson (RedHat)


### PR DESCRIPTION
The JCP informed us that Mathieu Ancelin has cancelled the JSPA 2.0 that enabled participation in the EG. Therefore, this PR removes him from the spec document.