### PR TITLE
Removed OracleJDKs from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
 jdk:
-- oraclejdk8
-- oraclejdk9
 - openjdk8
 - openjdk9
 - openjdk10


### PR DESCRIPTION
Travis doesn't support OracleJDK anymore. 

I didn't add JDK11 and JDK12 for now, as the build fails in this case. See #221 for details.