### PR TITLE
Fixed JDK11 compatibility issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ jdk:
 - openjdk8
 - openjdk9
 - openjdk10
+- openjdk11
+- openjdk12
 script:
   - mvn clean install -B -V
 deploy:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -137,6 +137,7 @@
                 <configuration>
                     <doctitle>MVC ${project.version} API</doctitle>
                     <windowtitle>MVC ${project.version} API</windowtitle>
+                    <source>8</source>
                 </configuration>
             </plugin>
             <plugin>

--- a/api/src/main/java/javax/mvc/security/Encoders.java
+++ b/api/src/main/java/javax/mvc/security/Encoders.java
@@ -31,7 +31,8 @@ public interface Encoders {
      * <p>Encoding for JavaScript code in attributes or script blocks. It MUST support
      * encoding of (at least) the following characters:</p>
      *
-     * <table summary="Encoding Table">
+     * <table>
+     * <caption>Encoding Table</caption>
      * <thead>
      * <tr><th>Input Character</th><th>Encoding</th></tr>
      * </thead>
@@ -59,7 +60,8 @@ public interface Encoders {
      * <p>Encoding for HTML code in attributes or content. It MUST support encoding of
      * (at least) the following characters:</p>
      *
-     * <table summary="Encoding Table">
+     * <table>
+     * <caption>Encoding Table</caption>
      * <thead>
      * <tr><th>Input Character</th><th>Encoding</th></tr>
      * </thead>


### PR DESCRIPTION
There build currently doesn't work on JDK11 and JDK12. This PR fixes the underlying issues:

- Replaced deprecated HTML attributes in javadocs with recommended alternative
- Fixed javadoc plugin to not complain about missing module descriptors
- Added new JDKs to Travis config