### PR TITLE
Updated EG member list

### DIFF
--- a/spec/src/main/asciidoc/chapters/intro.asciidoc
+++ b/spec/src/main/asciidoc/chapters/intro.asciidoc
@@ -129,6 +129,7 @@ This specification is being developed as part of https://jcp.org/en/jsr/detail?i
 |Christian Kaltepoth (ingenit GmbH & Co. KG)
 |Woong-ki Lee (TmaxSoft, Inc.)
 |Paul Nicolucci (IBM)
+|Kito D. Mann (Individual Member)
 |Rahman Usta (Individual Member)
 |Florian Hirsch (adorsys GmbH & Co KG)
 |Santiago Pericas-Geertsen (Oracle)
@@ -140,7 +141,7 @@ The following are former members of the expert group:
 [cols="1,1"] 
 |===
 |Guilherme de Azevedo Silveira (Individual Member)
-|Kito D. Mann (Individual Member)
+|
 |===
 
 [[contributors]]


### PR DESCRIPTION
We had to remove @kito99 from the EG member list, as the PMO informed us that his JSPA has expired. But his JSPA has been updated now, so I'm adding Kito again.