### PR TITLE
Publish the Spec to Github-Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 nbactions.xml
 nb-configuration.xml
 *.iml
+site.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,31 @@ jdk:
 - openjdk10
 - openjdk11
 - openjdk12
-script:
-  - mvn clean install -B -V
+
+cache:
+  directories:
+    - $HOME/.m2
+
+script: mvn clean install -B -V
+
 deploy:
-  provider: script
-  script: mvn -s .travis/deploy-settings.xml -DperformRelease -DskipTests -Dgpg.skip=true deploy
-  skip_cleanup: true
-  on:
-    repo: mvc-spec/mvc-spec
-    branch: master
-    jdk: openjdk8
+  - provider: script
+    script: mvn -s .travis/deploy-settings.xml -DperformRelease -DskipTests -Dgpg.skip=true deploy
+    skip_cleanup: true
+    on:
+      repo: mvc-spec/mvc-spec
+      branch: master
+      jdk: openjdk8
+  - provider: pages
+    skip_cleanup: true
+    script: skip
+    github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+    keep_history: true
+    local_dir: spec/target/generated-docs
+    on:
+      branch: master
+      jdk: openjdk8
+
 env:
   global:
     - secure: "iJFl971N9L3Bi1+2Z8DGexI+5VObaenykZB9+xohWEKSwzRjusa6/pmzk9+1Cm7RicwDubmx5kmcJvkZki5EF5wVP7lnuHodM2d281052qq/2TcaCN3/DmyGg1QuunCDvZpVWfu1e1F5KMwmp+brt6yaUQVPVN/ehKyT++niO7ZOlhjaB2Gn02bPwW8BZ8aEUt2mNPNwSOJ7R1g4yV+Ji7lleWTIMbJCa1bmg9YncHLyCU8un5vm/fok5fcmwZwrtnckbSU2fgIo8GDXKbblsHOSC2FeYfQFhFzMjh3+bhPhKHmQN7IG4puseNhsuJHGWAzK9hXdaacl+yZ+3WvPr7jf8E4ZL2RinCLaZwxkgHiImrm9Ay9FGMckyyobaPL3Uos1T2MBkhAIle9bh7GAw8GUYbZbCz+IUESTyloQn8Tg4Nspw7xna3W5uBzYySEBgJWKDnQBuWF9HOhJTzJunNWFfLrQEOXaQkyYks5+1VzMm2kKL10hJ55TwG/9zKA7AWspdeaK53ZdtzEfuVLfLymkpKZbtp872sdHbfveV8eeRwFoD4b8TF9K5oxMDQYzeP3N3zlpFsvXtjzQoAOxRE96n/1FiYTQQvbbiTf43lW/HI4QqyA6sV897zjdX5qhnTJT6iFZWxkCgt63Acnrz+CzMdFtL8CCEXnfJi/oIbY="

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ deploy:
     keep_history: true
     local_dir: spec/target/generated-docs
     on:
+      repo: mvc-spec/mvc-spec
       branch: master
       jdk: openjdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,9 @@ deploy:
       repo: mvc-spec/mvc-spec
       branch: master
       jdk: openjdk8
-  - provider: pages
+  - provider: script
+    script: .travis/deploy-spec-html.sh
     skip_cleanup: true
-    script: skip
-    github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
-    keep_history: true
-    local_dir: spec/target/generated-docs
     on:
       repo: mvc-spec/mvc-spec
       branch: master
@@ -35,3 +32,4 @@ env:
   global:
     - secure: "iJFl971N9L3Bi1+2Z8DGexI+5VObaenykZB9+xohWEKSwzRjusa6/pmzk9+1Cm7RicwDubmx5kmcJvkZki5EF5wVP7lnuHodM2d281052qq/2TcaCN3/DmyGg1QuunCDvZpVWfu1e1F5KMwmp+brt6yaUQVPVN/ehKyT++niO7ZOlhjaB2Gn02bPwW8BZ8aEUt2mNPNwSOJ7R1g4yV+Ji7lleWTIMbJCa1bmg9YncHLyCU8un5vm/fok5fcmwZwrtnckbSU2fgIo8GDXKbblsHOSC2FeYfQFhFzMjh3+bhPhKHmQN7IG4puseNhsuJHGWAzK9hXdaacl+yZ+3WvPr7jf8E4ZL2RinCLaZwxkgHiImrm9Ay9FGMckyyobaPL3Uos1T2MBkhAIle9bh7GAw8GUYbZbCz+IUESTyloQn8Tg4Nspw7xna3W5uBzYySEBgJWKDnQBuWF9HOhJTzJunNWFfLrQEOXaQkyYks5+1VzMm2kKL10hJ55TwG/9zKA7AWspdeaK53ZdtzEfuVLfLymkpKZbtp872sdHbfveV8eeRwFoD4b8TF9K5oxMDQYzeP3N3zlpFsvXtjzQoAOxRE96n/1FiYTQQvbbiTf43lW/HI4QqyA6sV897zjdX5qhnTJT6iFZWxkCgt63Acnrz+CzMdFtL8CCEXnfJi/oIbY="
     - secure: "SPvU5ZPDcFpIGScO42HXWrGoUw/s8IIDJrj9Ne343ag7dNXq91Kd2sxYE3EyYiZVt/6YIneYv4adezzfD94xHL2apiaIRy+OzheG8ohgU5nSxra4jXi+gUQMjrmIybL6qyQe7rDxI6zkUvjB6h10i3bZw4a6lf1afqFwmrHST6dXBqIKgmOJ668nzmOqxozjQ1PfbgS1N5D5s5Oh0zncIq7dqP26fK3lrytHfq+cfjMolNeE99CXDwy2HJkFoYtmjCCrT6mi5WzVUGa2g3w1nidDGqIIOIWImu4GLdgaKCZb55XFbtgTNzzYf8SXvmgqTxqftCL8pyLk1vMX3dxctn/E9AdwkhpcXouCJkDvSJ2LznYAjX0CwDIAK34/T7Ad60sjBpZGK17QcNRkvqyG6A8434GKbaY8sRXSQJIyTHgPNqDYTuYKJDehiKY2xF5zeG3aVjHO5jzoeNNMlgeOT3tjGZAK6z5szDQXSInMozMHqdu93pHSBzKn17e3pVGuelOo42B1bxsPSHQVbSWXIl0n2fhNe1B2k5PI++D4qwEBJ0Cpe9nwGmUJ0SB1u5omSDOiW2+cueE7dsUV6KWLvXolD8h37fVOkbgpULbIsJXLcwYnjP3Zvj4pf9KEPPSi5vgBYCOh0R1bLDh2emzcMPWlHlvZaeRCucTT7eJ4etI="
+    - secure: "oI7mgMf86wdd095VmfhrAHr0HQRXmBJqhLK0lvuXnNvRczS2lS/rQpNgzC1tuKdap47YPaTzo/zS0bKMnHfejwNoOPh2bvizHVYZXBXLAAY0lPAJZ0+ZV8WyLTVHfM+krsq5aJs2XHzbOr4oeEvNoVwyVKi0nD5Z+i7fT+9lawrak2P0CF0jTIe2noQiiQ51z/kIY46UJlEXw+0miN/MPLsfzAIMGldaemg+CbjKjUeMBD/RgOwN0J+95FnqKfM0IZ6HeT4jN/YTUJVgusWnu+kGUjJA4zIdT0xMMHqLdHyvOV0sogntwiBLjYkknNSmSQ7vpz4otzRcbeDFupmnUoeWRgNUZ86Gi3UCXz5DJgbwduufv52v2ne8CVElGKqrYst9ne+qxdWyPOOPRkIsvV1/BZjrHQaMLu11MgzB/2MLWXTTU9vVuvTJn43j7q1sdL99OPVF7mLKaVqIAXbRUCFs8dD/ZhmXbahQmhpt5If8g6+HPcz0FbXTkj4XjmuHH8RkJM4vpsNSPU/VzsCAciypnEIvsRBE2jO7njL0hBw2NSV0MwJT9IreqjTTz+jX72BvApxTlTIGbstOnaGY15QDhz3PAP4/pT/QHdt8vaRnePtCE0CGec9iGD7UJYlQt7eUpMHlEM+ACw6Ate2zmgKsg6r1VBr9qZORbWaQpsk="

--- a/.travis/deploy-spec-html.sh
+++ b/.travis/deploy-spec-html.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+echo "Creating site archive..."
+cd ${BASEDIR}/spec/target/generated-docs/
+zip -q -r ${BASEDIR}/site.zip *
+
+echo "Uploading archive..."
+cd ${BASEDIR}
+curl -s -H "Content-Type: application/zip" \
+     -H "Authorization: Bearer ${NETLIFY_TOKEN}" \
+     --data-binary "@site.zip" \
+     https://api.netlify.com/api/v1/sites/a36b2588-c345-47ea-95ed-3dbcfcd5cee9/deploys \
+     > /dev/null
+
+echo "Done"

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -79,6 +79,7 @@
                                 <linkcss>false</linkcss>
                                 <project-version>${project.version}</project-version>
                             </attributes>
+                            <outputFile>${project.build.directory}/generated-docs/index.html</outputFile>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
This would publish the spec to Github-Pages.
I saw the tcp coverage report is published to netlify, but I think it would be nice to keep everything in one place (and I was to lazy to setup netlify 😋 ). 

This still needs a Github token with Public-Repo Access set up in travis or as an encrypted variable in the `.travis.yml`. 

I tested it on my fork, here's how it would look like: https://gtudan.github.io/mvc-spec
A sidebar TOC would be nice for easier navigation, but I guess we can leave that for another PR...

closes #225