### PR TITLE
Fixed copyright line in file headers

### DIFF
--- a/LICENSE-JCP-nonfinal.txt
+++ b/LICENSE-JCP-nonfinal.txt
@@ -8,7 +8,7 @@ Status: Pre-FCS Public Release
 
 Release: Public Review Release
 
-Copyright 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+Copyright 2017 JSR 371 expert group and contributors
 All rights reserved.
 
 NOTICE

--- a/LICENSE-JCP.txt
+++ b/LICENSE-JCP.txt
@@ -10,7 +10,7 @@ Specification Lead:  Ivar Grimstad ("Specification Lead")
 
 Release:  Final Release
 
-Copyright 2019 Ivar Grimstad (ivar.grimstad@gmail.com)
+Copyright 2019 JSR 371 expert group and contributors
 All rights reserved.
 
 LIMITED LICENSE GRANTS

--- a/api/findbugs-exclude.xml
+++ b/api/findbugs-exclude.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+    Copyright (c) 2011-2013 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+    Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2016-2019 JSR 371 expert group and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -232,36 +232,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>3.0</version>
-                <configuration>
-                    <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
-                    <properties>
-                        <owner>Ivar Grimstad</owner>
-                        <email>ivar.grimstad@gmail.com</email>
-                        <project.inceptionYear>2017</project.inceptionYear>
-                    </properties>
-                    <includes>
-                        <include>src/**/*.java</include>
-                        <include>findbugs-exclude.xml</include>
-                        <include>pom.xml</include>
-                    </includes>
-                    <mapping>
-                        <java>SLASHSTAR_STYLE</java>
-                    </mapping>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>license-check</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/api/src/main/java/javax/mvc/Controller.java
+++ b/api/src/main/java/javax/mvc/Controller.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/Models.java
+++ b/api/src/main/java/javax/mvc/Models.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/MvcContext.java
+++ b/api/src/main/java/javax/mvc/MvcContext.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/RedirectScoped.java
+++ b/api/src/main/java/javax/mvc/RedirectScoped.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/UriRef.java
+++ b/api/src/main/java/javax/mvc/UriRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/View.java
+++ b/api/src/main/java/javax/mvc/View.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/binding/BindingError.java
+++ b/api/src/main/java/javax/mvc/binding/BindingError.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/binding/BindingResult.java
+++ b/api/src/main/java/javax/mvc/binding/BindingResult.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/binding/MvcBinding.java
+++ b/api/src/main/java/javax/mvc/binding/MvcBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2017-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/binding/ParamError.java
+++ b/api/src/main/java/javax/mvc/binding/ParamError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/binding/ValidationError.java
+++ b/api/src/main/java/javax/mvc/binding/ValidationError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/binding/package-info.java
+++ b/api/src/main/java/javax/mvc/binding/package-info.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2017 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/engine/ViewEngine.java
+++ b/api/src/main/java/javax/mvc/engine/ViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/engine/ViewEngineContext.java
+++ b/api/src/main/java/javax/mvc/engine/ViewEngineContext.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/engine/ViewEngineException.java
+++ b/api/src/main/java/javax/mvc/engine/ViewEngineException.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2017 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/engine/package-info.java
+++ b/api/src/main/java/javax/mvc/engine/package-info.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/event/AfterControllerEvent.java
+++ b/api/src/main/java/javax/mvc/event/AfterControllerEvent.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/event/AfterProcessViewEvent.java
+++ b/api/src/main/java/javax/mvc/event/AfterProcessViewEvent.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/event/BeforeControllerEvent.java
+++ b/api/src/main/java/javax/mvc/event/BeforeControllerEvent.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/event/BeforeProcessViewEvent.java
+++ b/api/src/main/java/javax/mvc/event/BeforeProcessViewEvent.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/event/ControllerRedirectEvent.java
+++ b/api/src/main/java/javax/mvc/event/ControllerRedirectEvent.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/event/MvcEvent.java
+++ b/api/src/main/java/javax/mvc/event/MvcEvent.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/event/package-info.java
+++ b/api/src/main/java/javax/mvc/event/package-info.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/locale/LocaleResolver.java
+++ b/api/src/main/java/javax/mvc/locale/LocaleResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2016-2017 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/locale/LocaleResolverContext.java
+++ b/api/src/main/java/javax/mvc/locale/LocaleResolverContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2016-2017 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/locale/package-info.java
+++ b/api/src/main/java/javax/mvc/locale/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2016-2017 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/package-info.java
+++ b/api/src/main/java/javax/mvc/package-info.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2017 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/security/Csrf.java
+++ b/api/src/main/java/javax/mvc/security/Csrf.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/security/CsrfProtected.java
+++ b/api/src/main/java/javax/mvc/security/CsrfProtected.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/security/CsrfValidationException.java
+++ b/api/src/main/java/javax/mvc/security/CsrfValidationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/security/Encoders.java
+++ b/api/src/main/java/javax/mvc/security/Encoders.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2019 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/javax/mvc/security/package-info.java
+++ b/api/src/main/java/javax/mvc/security/package-info.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018 JSR 371 expert group and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+    Copyright (c) 2017-2018 JSR 371 expert group and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+    Copyright (c) 2017-2019 JSR 371 expert group and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/spec/src/main/asciidoc/chapters/engines.asciidoc
+++ b/spec/src/main/asciidoc/chapters/engines.asciidoc
@@ -20,7 +20,7 @@ This is the interface that must be implemented by all MVC view engines:
 
 [source,java,numbered]
 ----
-include::{mvc-api-source-dir}javax/mvc/engine/ViewEngine.java[lines=18..-1]
+include::{mvc-api-source-dir}javax/mvc/engine/ViewEngine.java[lines=19..-1]
 ----
 
 [[selection_algorithm]]

--- a/spec/src/main/asciidoc/chapters/events.asciidoc
+++ b/spec/src/main/asciidoc/chapters/events.asciidoc
@@ -19,12 +19,12 @@ Observing events can be useful for applications to learn about the lifecycle of 
 
 [source,java,numbered]
 ----
-include::{mvc-api-source-dir}javax/mvc/event/BeforeControllerEvent.java[lines=21..-1]
+include::{mvc-api-source-dir}javax/mvc/event/BeforeControllerEvent.java[lines=22..-1]
 ----
 
 [source,java,numbered]
 ----
-include::{mvc-api-source-dir}javax/mvc/event/AfterControllerEvent.java[lines=21..-1]
+include::{mvc-api-source-dir}javax/mvc/event/AfterControllerEvent.java[lines=22..-1]
 ----
 
 Applications can monitor these events using an observer as shown next.
@@ -57,12 +57,12 @@ The <<view_engines>> section describes the algorithm used by implementations to 
 
 [source,java,numbered]
 ----
-include::{mvc-api-source-dir}javax/mvc/event/BeforeProcessViewEvent.java[lines=20..-1]
+include::{mvc-api-source-dir}javax/mvc/event/BeforeProcessViewEvent.java[lines=21..-1]
 ----
 
 [source,java,numbered]
 ----
-include::{mvc-api-source-dir}javax/mvc/event/AfterProcessViewEvent.java[lines=20..-1]
+include::{mvc-api-source-dir}javax/mvc/event/AfterProcessViewEvent.java[lines=21..-1]
 ----
 
 These events can be observed in a similar manner:
@@ -109,7 +109,7 @@ For more information about the interaction between views and models, the reader 
 
 [source,java,numbered]
 ----
-include::{mvc-api-source-dir}javax/mvc/event/ControllerRedirectEvent.java[lines=20..-1]
+include::{mvc-api-source-dir}javax/mvc/event/ControllerRedirectEvent.java[lines=23..-1]
 ----
 
 CDI events fired by implementations are _synchronous_, so it is recommended that applications carry out only simple tasks in their observer methods,

--- a/spec/src/main/asciidoc/chapters/license_jcp.asciidoc
+++ b/spec/src/main/asciidoc/chapters/license_jcp.asciidoc
@@ -12,7 +12,7 @@ Status:  Final Release +
 Specification Lead:  Ivar Grimstad ("Specification Lead") +
 Release:  Final Release
 
-Copyright 2019 Ivar Grimstad (ivar.grimstad@gmail.com) +
+Copyright 2019 JSR 371 expert group and contributors +
 All rights reserved.
 
 LIMITED LICENSE GRANTS

--- a/spec/src/main/xsl/tck-audit.xsl
+++ b/spec/src/main/xsl/tck-audit.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+    Copyright (c) 2018 JSR 371 expert group and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -135,7 +135,7 @@
         <xsl:text>&#10;</xsl:text>
         <xsl:comment>
 
-    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+    Copyright (c) 2016-2019 JSR 371 expert group and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pull request fixes the copyright headers in the project. Basically it restores the original Oracle copyright lines in the code that was transferred back then and it unifies the headers to correctly indicate the copyright for all content added later.

For all modifications after the transfer from Oracle, I added a generic copyright line like this:

    Copyright (c) 2016-2018 JSR 371 expert group and contributors

I hope that this is ok for everyone who contributed to the specification. If not, feel free to speak up.